### PR TITLE
A few minor fixes

### DIFF
--- a/src/SlackConnector.Tests.Integration/Configuration/ConfigReader.cs
+++ b/src/SlackConnector.Tests.Integration/Configuration/ConfigReader.cs
@@ -13,7 +13,7 @@ namespace SlackConnector.Tests.Integration.Configuration
         {
             if (Current == null)
             {
-                string fileName = Path.Combine(Environment.CurrentDirectory, @"configuration\config.json");
+                string fileName = Path.Combine(Environment.CurrentDirectory, Path.Combine(@"configuration", "config.json"));
                 if (!System.IO.File.Exists(fileName))
                 {
                     Assert.Inconclusive("Unable to load config file from: " + fileName);

--- a/src/SlackConnector/Connections/Messaging/ChatMessenger.cs
+++ b/src/SlackConnector/Connections/Messaging/ChatMessenger.cs
@@ -32,7 +32,7 @@ namespace SlackConnector.Connections.Messaging
 
             if (attachments != null && attachments.Any())
             {
-                request.AddParameter("attachment", JsonConvert.SerializeObject(attachments));
+                request.AddParameter("attachments", JsonConvert.SerializeObject(attachments));
             }
 
             IRestResponse response = await client.ExecutePostTaskAsync(request);

--- a/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
+++ b/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
@@ -14,6 +14,7 @@ namespace SlackConnector.Connections.Sockets
         public WebSocketClient(IMessageInterpreter interpreter, string url)
         {
             _webSocket = new WebSocketSharp.WebSocket(url);
+            _webSocket.Log.Level = WebSocketSharp.LogLevel.Warn;
             _webSocket.OnMessage += (sender, args) => OnMessage?.Invoke(sender, interpreter.InterpretMessage(args?.Data ?? ""));
             _webSocket.OnClose += (sender, args) => OnClose?.Invoke(sender, args);
         }


### PR DESCRIPTION
- Fixed typo in request parameter
- Changed log level for WebSocket client to Warn
- Made configuration path OS agnostic

Couldn't change target framework to 4.5 since there is no way for me to validate that the current build script or modified project files work in Visual Studio (nuget pack from project files is not supported in Mono)  
