### PR TITLE
Make sure we do not duplicate message ids when sending a lot of messages in parallel.

### DIFF
--- a/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
+++ b/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
@@ -45,7 +45,7 @@ namespace SlackConnector.Connections.Sockets
 
         public async Task SendMessage(BaseMessage message)
         {
-            _currentMessageId++;
+            System.Threading.Interlocked.Increment(ref _currentMessageId);
             message.Id = _currentMessageId;
             string json = JsonConvert.SerializeObject(message);
 


### PR DESCRIPTION
If you push messages very fast, sometimes you get the same message id twice.
