### PR TITLE
Enable both automatic (by the WebsocketClient) and manual (by calling Ping) keep-alives.

### DIFF
--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -54,6 +54,11 @@ namespace SlackConnector.Tests.Unit.Stubs
             throw new NotImplementedException();
         }
 
+        public Task Ping()
+        {
+            throw new NotImplementedException();
+        }
+
         public event DisconnectEventHandler OnDisconnect;
         public void RaiseOnDisconnect()
         {

--- a/src/SlackConnector/Connections/Sockets/Messages/Outbound/PingMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Outbound/PingMessage.cs
@@ -1,0 +1,8 @@
+﻿using Newtonsoft.Json;
+
+namespace SlackConnector.Connections.Sockets.Messages.Outbound
+{
+    internal class PingMessage : BaseMessage
+    {
+    }
+}

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -81,6 +81,12 @@ namespace SlackConnector
         Task IndicateTyping(SlackChatHub chatHub);
 
         /// <summary>
+        /// Sends a Ping message to the server to detect if the client is disconnected
+        /// </summary>
+        /// <returns></returns>
+        Task Ping();
+
+        /// <summary>
         /// Raised when the websocket disconnects from the mothership.
         /// </summary>
         event DisconnectEventHandler OnDisconnect;

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -165,6 +165,16 @@ namespace SlackConnector
             await _webSocketClient.SendMessage(message);
         }
 
+        public async Task Ping()
+        {
+            var message = new PingMessage
+            {
+                Type = "ping"
+            };
+
+            await _webSocketClient.SendMessage(message);
+        }
+
         public event DisconnectEventHandler OnDisconnect;
         private void RaiseOnDisconnect()
         {

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Connections\Responses\UsersResponse.cs" />
     <Compile Include="Connections\RestSharpFactory.cs" />
     <Compile Include="Connections\Sockets\Messages\Outbound\BaseMessage.cs" />
+    <Compile Include="Connections\Sockets\Messages\Outbound\PingMessage.cs" />
     <Compile Include="Connections\Sockets\Messages\Outbound\TypingIndicatorMessage.cs" />
     <Compile Include="ConsoleLoggingLevel.cs" />
     <Compile Include="EventHandlers\DisconnectEventHandler.cs" />


### PR DESCRIPTION
Ping can also be used to detect if the bot has disconnected.

Not 100% reliable, as some of the exceptions do not "bubble" into Send, but are reported through `WebSocket.OnError`, but supporting them would require a more extensive refactoring of `WebSocketClient`
