### PR TITLE
Added support for Group_Joined and Channel_Joined events

### DIFF
--- a/src/SlackConnector.Tests.Unit/Connections/Sockets/Messages/MessageInterpreterTests.cs
+++ b/src/SlackConnector.Tests.Unit/Connections/Sockets/Messages/MessageInterpreterTests.cs
@@ -34,7 +34,7 @@ namespace SlackConnector.Tests.Unit.Connections.Sockets.Messages
         [Test]
         public void then_should_look_like_expected()
         {
-            var expected = new InboundMessage
+            var expected = new ChatMessage
             {
                 MessageType = MessageType.Message,
                 Channel = "<myChannel>",
@@ -67,7 +67,7 @@ namespace SlackConnector.Tests.Unit.Connections.Sockets.Messages
         [Test]
         public void then_should_look_like_expected()
         {
-            var expected = new InboundMessage
+            var expected = new ChatMessage
             {
                 MessageType = MessageType.Unknown,
                 RawData = Json

--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -70,5 +70,11 @@ namespace SlackConnector.Tests.Unit.Stubs
         {
             OnMessageReceived?.Invoke(null);
         }
+
+        public event ChatHubJoinedEventHandler OnChatHubJoined;
+        public void RaiseOnChatHubJoined()
+        {
+            OnChatHubJoined?.Invoke(null);
+        }
     }
 }

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChannelJoinedMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChannelJoinedMessage.cs
@@ -1,0 +1,14 @@
+using SlackConnector.Connections.Models;
+
+namespace SlackConnector.Connections.Sockets.Messages.Inbound
+{
+    internal class ChannelJoinedMessage : InboundMessage
+    {
+        public ChannelJoinedMessage()
+        {
+            MessageType = MessageType.Channel_Joined;
+        }
+
+        public Channel Channel { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using SlackConnector.Serialising;
+
+namespace SlackConnector.Connections.Sockets.Messages.Inbound
+{
+    internal class ChatMessage : InboundMessage
+    {
+        public ChatMessage()
+        {
+            MessageType = MessageType.Message;
+        }
+
+        [JsonProperty("subtype")]
+        [JsonConverter(typeof(EnumConverter))]
+        public MessageSubType MessageSubType { get; set; }
+
+        public string Channel { get; set; }
+        public string User { get; set; }
+        public string Text { get; set; }
+        public string Team { get; set; }
+
+        [JsonProperty("ts")]
+        public double TimeStamp { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/GroupJoinedMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/GroupJoinedMessage.cs
@@ -1,0 +1,14 @@
+using SlackConnector.Connections.Models;
+
+namespace SlackConnector.Connections.Sockets.Messages.Inbound
+{
+    internal class GroupJoinedMessage : InboundMessage
+    {
+        public GroupJoinedMessage()
+        {
+            MessageType = MessageType.Group_Joined;
+        }
+
+        public Group Channel { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/InboundMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/InboundMessage.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using SlackConnector.Serialising;
 
 namespace SlackConnector.Connections.Sockets.Messages.Inbound
@@ -9,17 +9,6 @@ namespace SlackConnector.Connections.Sockets.Messages.Inbound
         [JsonConverter(typeof(EnumConverter))]
         public MessageType MessageType { get; set; }
 
-        [JsonProperty("subtype")]
-        [JsonConverter(typeof(EnumConverter))]
-        public MessageSubType MessageSubType { get; set; }
-
-        public string Channel { get; set; }
-        public string User { get; set; }
-        public string Text { get; set; }
-        public string Team { get; set; }
         public string RawData { get; set; }
-
-        [JsonProperty("ts")]
-        public double TimeStamp { get; set; }
     }
 }

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/MessageType.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/MessageType.cs
@@ -3,6 +3,8 @@
     internal enum MessageType
     {
         Unknown = 0,
-        Message
+        Message,
+        Group_Joined,
+        Channel_Joined,
     }
 }

--- a/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
+++ b/src/SlackConnector/Connections/Sockets/WebSocketClient.cs
@@ -76,7 +76,7 @@ namespace SlackConnector.Connections.Sockets
         private void WebSocketOnMessage(object sender, MessageEventArgs args)
         {
             string messageJson = args?.Data ?? "";
-            InboundMessage inboundMessage = _interpreter.InterpretMessage(messageJson);
+            var inboundMessage = _interpreter.InterpretMessage(messageJson);
             OnMessage?.Invoke(sender, inboundMessage);
         }
     }

--- a/src/SlackConnector/EventHandlers/ChatHubJoinedEventHandler.cs
+++ b/src/SlackConnector/EventHandlers/ChatHubJoinedEventHandler.cs
@@ -1,0 +1,7 @@
+using System.Threading.Tasks;
+using SlackConnector.Models;
+
+namespace SlackConnector.EventHandlers
+{
+    public delegate Task ChatHubJoinedEventHandler(SlackChatHub chatHub);
+}

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -95,5 +95,7 @@ namespace SlackConnector
         /// Raised when real-time messages are received.
         /// </summary>
         event MessageReceivedEventHandler OnMessageReceived;
+
+        event ChatHubJoinedEventHandler OnChatHubJoined;
     }
 }

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -80,10 +80,14 @@
     <Compile Include="Connections\Responses\StandardResponse.cs" />
     <Compile Include="Connections\Responses\UsersResponse.cs" />
     <Compile Include="Connections\RestSharpFactory.cs" />
+    <Compile Include="Connections\Sockets\Messages\Inbound\ChannelJoinedMessage.cs" />
+    <Compile Include="Connections\Sockets\Messages\Inbound\GroupJoinedMessage.cs" />
+    <Compile Include="Connections\Sockets\Messages\Inbound\InboundMessage.cs" />
     <Compile Include="Connections\Sockets\Messages\Outbound\BaseMessage.cs" />
     <Compile Include="Connections\Sockets\Messages\Outbound\PingMessage.cs" />
     <Compile Include="Connections\Sockets\Messages\Outbound\TypingIndicatorMessage.cs" />
     <Compile Include="ConsoleLoggingLevel.cs" />
+    <Compile Include="EventHandlers\ChatHubJoinedEventHandler.cs" />
     <Compile Include="EventHandlers\DisconnectEventHandler.cs" />
     <Compile Include="Exceptions\AlreadyConnectedException.cs" />
     <Compile Include="Exceptions\CommunicationException.cs" />
@@ -116,7 +120,7 @@
     <Compile Include="Models\SlackUser.cs" />
     <Compile Include="Connections\Sockets\IWebSocketClient.cs" />
     <Compile Include="Connections\Sockets\Messages\Inbound\IMessageInterpreter.cs" />
-    <Compile Include="Connections\Sockets\Messages\Inbound\InboundMessage.cs" />
+    <Compile Include="Connections\Sockets\Messages\Inbound\ChatMessage.cs" />
     <Compile Include="Connections\Sockets\Messages\Inbound\MessageInterpreter.cs" />
     <Compile Include="Connections\Sockets\Messages\Inbound\MessageSubType.cs" />
     <Compile Include="Connections\Sockets\Messages\Inbound\MessageType.cs" />


### PR DESCRIPTION
Both are translated into SlackConnection.OnChatHubJoined

I had to refactor a bunch of things, but tried to keep it as generic as possible. Now it's easier to support new message types, even though new implementations will need some copy-pasting.

The changes could be reduced if Group and Channel would share a common base class. (Or if both would implement the same interface, like `IAmAChatHub`, or `ICanGiveYouAChatHub`)

