### PR TITLE
Added markdown flagging for attachments

### DIFF
--- a/SlackConnector.sln
+++ b/SlackConnector.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackConnector", "src\SlackConnector\SlackConnector.csproj", "{83D8B2DB-2033-4EA4-9129-110A20DBA7D5}"
 EndProject

--- a/src/SlackConnector.Tests.Integration/Configuration/Config.cs
+++ b/src/SlackConnector.Tests.Integration/Configuration/Config.cs
@@ -3,5 +3,14 @@
     public class Config
     {
         public SlackConfig Slack { get; set; }
+        public bool IsConfigured
+        {
+            get
+            {
+                return Slack != null
+                    && string.IsNullOrWhiteSpace(Slack.ApiToken) == false
+                    && string.IsNullOrWhiteSpace(Slack.TestUserId) == false;
+            }
+        }
     }
 }

--- a/src/SlackConnector.Tests.Integration/JoinDmChannelTests.cs
+++ b/src/SlackConnector.Tests.Integration/JoinDmChannelTests.cs
@@ -14,6 +14,7 @@ namespace SlackConnector.Tests.Integration
         {
             // given
             var config = new ConfigReader().GetConfig();
+            if (config.IsConfigured == false) { Assert.Ignore();}
 
             var slackConnector = new SlackConnector();
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;

--- a/src/SlackConnector.Tests.Integration/SayTests.cs
+++ b/src/SlackConnector.Tests.Integration/SayTests.cs
@@ -14,7 +14,8 @@ namespace SlackConnector.Tests.Integration
         {
             // given
             var config = new ConfigReader().GetConfig();
-            
+            if (config.IsConfigured == false) { Assert.Ignore(); }
+
             var slackConnector = new SlackConnector();
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;
             var message = new BotMessage

--- a/src/SlackConnector.Tests.Integration/SlackConnectorTests.cs
+++ b/src/SlackConnector.Tests.Integration/SlackConnectorTests.cs
@@ -13,6 +13,8 @@ namespace SlackConnector.Tests.Integration
         {
             // given
             var config = new ConfigReader().GetConfig();
+            if (config.IsConfigured == false) { Assert.Ignore(); }
+
             var slackConnector = new SlackConnector();
 
             // when

--- a/src/SlackConnector.Tests.Integration/SlackGetChannels.cs
+++ b/src/SlackConnector.Tests.Integration/SlackGetChannels.cs
@@ -14,6 +14,8 @@ namespace SlackConnector.Tests.Integration
             {
                 // given
                 var config = new ConfigReader().GetConfig();
+                if (config.IsConfigured == false) { Assert.Ignore(); }
+
                 var slackConnector = new SlackConnector();
 
                 // when
@@ -29,6 +31,8 @@ namespace SlackConnector.Tests.Integration
             {
                 // given
                 var config = new ConfigReader().GetConfig();
+                if (config.IsConfigured == false) { Assert.Ignore(); }
+
                 var slackConnector = new SlackConnector();
 
                 // when

--- a/src/SlackConnector.Tests.Integration/TypingIndicatorTests.cs
+++ b/src/SlackConnector.Tests.Integration/TypingIndicatorTests.cs
@@ -14,6 +14,7 @@ namespace SlackConnector.Tests.Integration
         {
             // given
             var config = new ConfigReader().GetConfig();
+            if (config.IsConfigured == false) { Assert.Ignore(); }
 
             var slackConnector = new SlackConnector();
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;

--- a/src/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
+++ b/src/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
@@ -30,6 +30,7 @@ namespace SlackConnector.Tests.Unit.Models
                     TitleLink = "https://api.slack.com/",
                     Text = "Optional text that appears within the attachment",
                     CallbackId = "mycallbackid",
+                    MarkdownIn = SlackAttachment.GetAllMarkdownInTypes(),
                     Fields = new[]
                     {
                         new SlackAttachmentField

--- a/src/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
+++ b/src/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
@@ -32,5 +32,6 @@
         }
     ],
     "image_url": "http://my-website.com/path/to/image.jpg",
-    "thumb_url": "http://example.com/path/to/thumb.png"
+    "thumb_url": "http://example.com/path/to/thumb.png",
+    "mrkdwn_in": ["fields","pretext","text"]
 }

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/MessageInterpreter.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/MessageInterpreter.cs
@@ -45,6 +45,11 @@ namespace SlackConnector.Connections.Sockets.Messages.Inbound
 
         private static MessageType ParseMessageType(string json)
         {
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return MessageType.Unknown;
+            }
+
             var messageJobject = JObject.Parse(json);
             MessageType messageType;
             if (!Enum.TryParse(messageJobject["type"].Value<string>(), true, out messageType))

--- a/src/SlackConnector/Models/SlackAttachment.cs
+++ b/src/SlackConnector/Models/SlackAttachment.cs
@@ -47,6 +47,23 @@ namespace SlackConnector.Models
         [JsonProperty(PropertyName = "thumb_url")]
         public string ThumbUrl { get; set; }
 
+        [JsonProperty(PropertyName = "mrkdwn_in")]
+        public List<string> MarkdownIn { get; set; }
+
+        public const string MARKDOWN_IN_PRETEXT = "pretext";
+        public const string MARKDOWN_IN_TEXT = "text";
+        public const string MARKDOWN_IN_FIELDS = "pretext";
+
+        public static List<string> GetAllMarkdownInTypes()
+        {
+            return new List<string>
+            {
+                MARKDOWN_IN_FIELDS,
+                MARKDOWN_IN_PRETEXT,
+                MARKDOWN_IN_TEXT
+            };
+        }
+
         public SlackAttachment()
         {
             Fields = new List<SlackAttachmentField>();

--- a/src/SlackConnector/Models/SlackAttachment.cs
+++ b/src/SlackConnector/Models/SlackAttachment.cs
@@ -52,7 +52,7 @@ namespace SlackConnector.Models
 
         public const string MARKDOWN_IN_PRETEXT = "pretext";
         public const string MARKDOWN_IN_TEXT = "text";
-        public const string MARKDOWN_IN_FIELDS = "pretext";
+        public const string MARKDOWN_IN_FIELDS = "fields";
 
         public static List<string> GetAllMarkdownInTypes()
         {


### PR DESCRIPTION
covered in #26  . I had forgotten to update the tests to account for this. 

I also put in an Assert.Ignore() in the integration tests if there isnt any value in the config.json. I can't compile without that file, and the commit build seems to want to run the integration tests and I cant find out another way to avoid running them. Let me know if you want that part redone or if you have other alternatives. 

Thanks! 