### PR TITLE
Using a more descriptive variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install-Package SlackConnector
 
 ``` cs
 ISlackConnector connector = new SlackConnector.SlackConnector();
-ISlackConnection connection = await connector.Connect(slackKey);
+ISlackConnection connection = await connector.Connect(botAccessToken);
 connection.OnMessageReceived += MessageReceived;
 connection.OnDisconnect += Disconnected;
 ```


### PR DESCRIPTION
I was really confused as to what a `slackKey` was supposed to mean.  Slack calls it a Bot Access Token. It would be better to use that terminology I think.

There was apparently [one other user](https://github.com/noobot/SlackConnector/issues/23) who also didn't know what `slackKey` meant.