### PR TITLE
Support for uploading files to Slack

### DIFF
--- a/src/SlackConnector.Tests.Integration/Configuration/SlackConfig.cs
+++ b/src/SlackConnector.Tests.Integration/Configuration/SlackConfig.cs
@@ -4,5 +4,6 @@
     {
         public string ApiToken { get; set; }
         public string TestUserId { get; set; }
+        public string TestChannel { get; set; }
     }
 }

--- a/src/SlackConnector.Tests.Integration/Configuration/SlackConfig.cs
+++ b/src/SlackConnector.Tests.Integration/Configuration/SlackConfig.cs
@@ -5,5 +5,6 @@
         public string ApiToken { get; set; }
         public string TestUserId { get; set; }
         public string TestChannel { get; set; }
+        public string TestFile { get; set; }
     }
 }

--- a/src/SlackConnector.Tests.Integration/Configuration/UploadTest.txt
+++ b/src/SlackConnector.Tests.Integration/Configuration/UploadTest.txt
@@ -1,0 +1,1 @@
+﻿This is the file we are using for integration testing.

--- a/src/SlackConnector.Tests.Integration/Configuration/config.default.json
+++ b/src/SlackConnector.Tests.Integration/Configuration/config.default.json
@@ -1,6 +1,7 @@
 ﻿{
   "slack": {
     "apiToken": "",
-    "testUserId":  ""
+    "testUserId": "",
+    "testChannel": ""
   }
 }

--- a/src/SlackConnector.Tests.Integration/Configuration/config.default.json
+++ b/src/SlackConnector.Tests.Integration/Configuration/config.default.json
@@ -2,6 +2,7 @@
   "slack": {
     "apiToken": "",
     "testUserId": "",
-    "testChannel": ""
+    "testChannel": "",
+    "testFile":  "" 
   }
 }

--- a/src/SlackConnector.Tests.Integration/FileUploadTests.cs
+++ b/src/SlackConnector.Tests.Integration/FileUploadTests.cs
@@ -11,7 +11,7 @@ namespace SlackConnector.Tests.Integration
     class FileUploadTests
     {
         [Test]
-        public void should_upload_to_channel()
+        public void should_upload_to_channel_from_file_system()
         {
             // given
             var config = new ConfigReader().GetConfig();
@@ -20,7 +20,7 @@ namespace SlackConnector.Tests.Integration
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;
             var fileupload = new BotFileUpload
             {
-                File = Directory.GetCurrentDirectory() + "\\UploadTest.txt",
+                File = Directory.GetCurrentDirectory() + "\\" + config.Slack.TestFile,
                 ChatHub = connection.ConnectedChannels().First(x => x.Name.Equals(config.Slack.TestChannel, StringComparison.InvariantCultureIgnoreCase))
             };
 
@@ -29,5 +29,34 @@ namespace SlackConnector.Tests.Integration
 
             // then
         }
+
+        [Test]
+        public void should_upload_to_channel_from_stream()
+        {
+            // given
+            var config = new ConfigReader().GetConfig();
+
+            var slackConnector = new SlackConnector();
+            var connection = slackConnector.Connect(config.Slack.ApiToken).Result;
+            var filePath = Directory.GetCurrentDirectory() + "\\" + config.Slack.TestFile;
+            using (var fileStream = File.Open(filePath, FileMode.Open))
+            {
+                var fileupload = new BotStreamUpload()
+                {
+                    FileName = config.Slack.TestFile,
+                    Stream = fileStream,
+                    ChatHub =
+                        connection.ConnectedChannels()
+                            .First(
+                                x =>
+                                    x.Name.Equals(config.Slack.TestChannel, StringComparison.InvariantCultureIgnoreCase))
+                };
+
+                // when
+                connection.Upload(fileupload).Wait();
+            }
+            // then
+        }
+
     }
 }

--- a/src/SlackConnector.Tests.Integration/FileUploadTests.cs
+++ b/src/SlackConnector.Tests.Integration/FileUploadTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.IO;
 using NUnit.Framework;
 using SlackConnector.Models;
 using SlackConnector.Tests.Integration.Configuration;
@@ -7,24 +8,24 @@ using SlackConnector.Tests.Integration.Configuration;
 namespace SlackConnector.Tests.Integration
 {
     [TestFixture]
-    public class SayTests
+    class FileUploadTests
     {
         [Test]
-        public void should_say_something_on_channel()
+        public void should_upload_to_channel()
         {
             // given
             var config = new ConfigReader().GetConfig();
 
             var slackConnector = new SlackConnector();
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;
-            var message = new BotMessage
+            var fileupload = new BotFileUpload
             {
-                Text = "Test text for INT test",
+                File = Directory.GetCurrentDirectory() + "\\UploadTest.txt",
                 ChatHub = connection.ConnectedChannels().First(x => x.Name.Equals(config.Slack.TestChannel, StringComparison.InvariantCultureIgnoreCase))
             };
-            
+
             // when
-            connection.Say(message).Wait();
+            connection.Upload(fileupload).Wait();
 
             // then
         }

--- a/src/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
+++ b/src/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
@@ -65,7 +65,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="Configuration\config.default.json" />
-    <None Include="Configuration\config.json" />
+    <None Include="Configuration\config.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -78,7 +80,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Configuration\UploadTest.txt" />
+    <Content Include="Configuration\UploadTest.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
+++ b/src/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
@@ -54,6 +54,7 @@
     <Compile Include="Configuration\ConfigReader.cs" />
     <Compile Include="Configuration\IConfigReader.cs" />
     <Compile Include="Configuration\SlackConfig.cs" />
+    <Compile Include="FileUploadTests.cs" />
     <Compile Include="SayTests.cs" />
     <Compile Include="JoinDmChannelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -64,9 +65,7 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="Configuration\config.default.json" />
-    <None Include="Configuration\config.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Include="Configuration\config.json" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -78,7 +77,14 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Configuration\UploadTest.txt" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/SlackConnector.Tests.Integration/TypingIndicatorTests.cs
+++ b/src/SlackConnector.Tests.Integration/TypingIndicatorTests.cs
@@ -17,7 +17,7 @@ namespace SlackConnector.Tests.Integration
 
             var slackConnector = new SlackConnector();
             var connection = slackConnector.Connect(config.Slack.ApiToken).Result;
-            SlackChatHub channel = connection.ConnectedChannels().First(x => x.Name.Equals("#general", StringComparison.InvariantCultureIgnoreCase));
+            SlackChatHub channel = connection.ConnectedChannels().First(x => x.Name.Equals(config.Slack.TestChannel, StringComparison.InvariantCultureIgnoreCase));
 
             // when
             connection.IndicateTyping(channel).Wait();

--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NUnit.Core;
 using SlackConnector.EventHandlers;
 using SlackConnector.Models;
 
@@ -36,6 +37,11 @@ namespace SlackConnector.Tests.Unit.Stubs
         }
 
         public Task Upload(BotFileUpload upload)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Upload(BotStreamUpload upload)
         {
             throw new NotImplementedException();
         }

--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -35,6 +35,11 @@ namespace SlackConnector.Tests.Unit.Stubs
             throw new NotImplementedException();
         }
 
+        public Task Upload(BotFileUpload upload)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<IEnumerable<SlackChatHub>> GetChannels()
         {
           throw new NotImplementedException();

--- a/src/SlackConnector/Connections/Clients/Chat/ChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/ChatClient.cs
@@ -13,7 +13,6 @@ namespace SlackConnector.Connections.Clients.Chat
     {
         private readonly IRequestExecutor _requestExecutor;
         internal const string SEND_MESSAGE_PATH = "/api/chat.postMessage";
-        internal const string FILE_UPLOAD_PATH = "/api/files.upload";
 
         public ChatClient(IRequestExecutor requestExecutor)
         {
@@ -33,17 +32,6 @@ namespace SlackConnector.Connections.Clients.Chat
                 request.AddParameter("attachments", JsonConvert.SerializeObject(attachments));
             }
 
-            await _requestExecutor.Execute<StandardResponse>(request);
-        }
-
-
-        public async Task PostFile(string slackKey, string channel, string file)
-        {
-            var request = new RestRequest(FILE_UPLOAD_PATH);
-            request.AddParameter("token", slackKey);
-            request.AddParameter("channels", channel);
-            request.AddParameter("filename", Path.GetFileName(file));
-            request.AddFile("file", file);
             await _requestExecutor.Execute<StandardResponse>(request);
         }
     }

--- a/src/SlackConnector/Connections/Clients/Chat/ChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/ChatClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.IO;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using RestSharp;
@@ -12,6 +13,7 @@ namespace SlackConnector.Connections.Clients.Chat
     {
         private readonly IRequestExecutor _requestExecutor;
         internal const string SEND_MESSAGE_PATH = "/api/chat.postMessage";
+        internal const string FILE_UPLOAD_PATH = "/api/files.upload";
 
         public ChatClient(IRequestExecutor requestExecutor)
         {
@@ -31,6 +33,17 @@ namespace SlackConnector.Connections.Clients.Chat
                 request.AddParameter("attachments", JsonConvert.SerializeObject(attachments));
             }
 
+            await _requestExecutor.Execute<StandardResponse>(request);
+        }
+
+
+        public async Task PostFile(string slackKey, string channel, string file)
+        {
+            var request = new RestRequest(FILE_UPLOAD_PATH);
+            request.AddParameter("token", slackKey);
+            request.AddParameter("channels", channel);
+            request.AddParameter("filename", Path.GetFileName(file));
+            request.AddFile("file", file);
             await _requestExecutor.Execute<StandardResponse>(request);
         }
     }

--- a/src/SlackConnector/Connections/Clients/Chat/FileClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/FileClient.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using RestSharp;
+using SlackConnector.Connections.Responses;
+
+namespace SlackConnector.Connections.Clients.Chat
+{
+    class FileClient : IFileClient
+    {
+        private readonly IRequestExecutor _requestExecutor;
+        internal const string FILE_UPLOAD_PATH = "/api/files.upload";
+
+        public FileClient(IRequestExecutor requestExecutor)
+        {
+            _requestExecutor = requestExecutor;
+        }
+
+        public async Task PostFile(string slackKey, string channel, string file)
+        {
+            var request = new RestRequest(FILE_UPLOAD_PATH);
+            request.AddParameter("token", slackKey);
+            request.AddParameter("channels", channel);
+            request.AddParameter("filename", Path.GetFileName(file));
+            request.AddFile("file", file);
+            await _requestExecutor.Execute<StandardResponse>(request);
+        }
+
+        public async Task PostFile(string slackKey, string channel, Stream stream, string fileName)
+        {
+            var request = new RestRequest(FILE_UPLOAD_PATH);
+            byte[] data = new byte[stream.Length];
+            stream.Read(data, 0, data.Length);
+            request.AddParameter("token", slackKey);
+            request.AddParameter("channels", channel);
+            request.AddParameter("filename", fileName);
+            request.AddFile("file", data, fileName);
+            await _requestExecutor.Execute<StandardResponse>(request);
+        }
+    }
+}

--- a/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
@@ -7,6 +7,5 @@ namespace SlackConnector.Connections.Clients.Chat
     internal interface IChatClient
     {
         Task PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
-        Task PostFile(string slackKey, string channel, string file);
     }
 }

--- a/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
@@ -7,5 +7,6 @@ namespace SlackConnector.Connections.Clients.Chat
     internal interface IChatClient
     {
         Task PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
+        Task PostFile(string slackKey, string channel, string file);
     }
 }

--- a/src/SlackConnector/Connections/Clients/Chat/IFileClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/IFileClient.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace SlackConnector.Connections.Clients.Chat
+{
+    interface IFileClient
+    {
+        Task PostFile(string slackKey, string channel, string filePath);
+        Task PostFile(string slackKey, string channel, Stream stream, string fileName);
+    }
+}

--- a/src/SlackConnector/Connections/ConnectionFactory.cs
+++ b/src/SlackConnector/Connections/ConnectionFactory.cs
@@ -34,6 +34,11 @@ namespace SlackConnector.Connections
             return new ChatClient(_requestExecutor);
         }
 
+        public IFileClient CreateFileClient()
+        {
+            return new FileClient(_requestExecutor);
+        }
+
         public IChannelClient CreateChannelClient()
         {
             return new ChannelClient(_requestExecutor);

--- a/src/SlackConnector/Connections/IConnectionFactory.cs
+++ b/src/SlackConnector/Connections/IConnectionFactory.cs
@@ -10,6 +10,7 @@ namespace SlackConnector.Connections
         IWebSocketClient CreateWebSocketClient(string url, ProxySettings proxySettings);
         IHandshakeClient CreateHandshakeClient();
         IChatClient CreateChatClient();
+        IFileClient CreateFileClient();
         IChannelClient CreateChannelClient();
     }
 }

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -68,7 +68,12 @@ namespace SlackConnector
         /// Uploads file to a Slack channel
         /// </summary>
         Task Upload(BotFileUpload fileupload);
-        
+
+        /// <summary>
+        /// Uploads a stream to a Slack channel as a file
+        /// </summary>
+        Task Upload(BotStreamUpload streamUpload);
+
         /// <summary>
         /// Get all channels and groups info.
         /// </summary>

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -63,7 +63,12 @@ namespace SlackConnector
         /// Send message to Slack channel.
         /// </summary>
         Task Say(BotMessage message);
-
+        
+        /// <summary>
+        /// Uploads file to a Slack channel
+        /// </summary>
+        Task Upload(BotFileUpload fileupload);
+        
         /// <summary>
         /// Get all channels and groups info.
         /// </summary>

--- a/src/SlackConnector/Models/BotFileUpload.cs
+++ b/src/SlackConnector/Models/BotFileUpload.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace SlackConnector.Models
+{
+    public class BotFileUpload
+    {
+        public SlackChatHub ChatHub { get; set; }
+        public string File { get; set; }
+    }
+}

--- a/src/SlackConnector/Models/BotStreamUpload.cs
+++ b/src/SlackConnector/Models/BotStreamUpload.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace SlackConnector.Models
+{
+    public class BotStreamUpload
+    {
+        public SlackChatHub ChatHub { get; set; }
+        public Stream Stream { get; set; }
+        public string FileName { get; set; }
+    }
+}

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -147,6 +147,12 @@ namespace SlackConnector
             await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
         }
 
+        public async Task Upload(BotFileUpload fileUpload)
+        {
+            var client = _connectionFactory.CreateChatClient();
+            await client.PostFile(SlackKey, fileUpload.ChatHub.Id, fileUpload.File);
+        }
+
         public async Task<IEnumerable<SlackChatHub>> GetChannels()
         {
             IChannelClient client = _connectionFactory.CreateChannelClient();

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -149,8 +149,14 @@ namespace SlackConnector
 
         public async Task Upload(BotFileUpload fileUpload)
         {
-            var client = _connectionFactory.CreateChatClient();
+            var client = _connectionFactory.CreateFileClient();
             await client.PostFile(SlackKey, fileUpload.ChatHub.Id, fileUpload.File);
+        }
+
+        public async Task Upload(BotStreamUpload streamUpload)
+        {
+            var client = _connectionFactory.CreateFileClient();
+            await client.PostFile(SlackKey, streamUpload.ChatHub.Id, streamUpload.Stream, streamUpload.FileName);
         }
 
         public async Task<IEnumerable<SlackChatHub>> GetChannels()

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -59,6 +59,8 @@
     <Compile Include="BotHelpers\ChatHubInterpreter.cs" />
     <Compile Include="BotHelpers\IMentionDetector.cs" />
     <Compile Include="BotHelpers\IChatHubInterpreter.cs" />
+    <Compile Include="Connections\Clients\Chat\FileClient.cs" />
+    <Compile Include="Connections\Clients\Chat\IFileClient.cs" />
     <Compile Include="Connections\Clients\IRequestExecutor.cs" />
     <Compile Include="Connections\Clients\RequestExecutor.cs" />
     <Compile Include="Connections\ConnectionFactory.cs" />
@@ -109,6 +111,7 @@
     <Compile Include="Connections\Models\Detail.cs" />
     <Compile Include="Connections\Models\Im.cs" />
     <Compile Include="Connections\Models\User.cs" />
+    <Compile Include="Models\BotStreamUpload.cs" />
     <Compile Include="Models\ConnectionInformation.cs" />
     <Compile Include="Models\ContactDetails.cs" />
     <Compile Include="Models\SlackAttachmentAction.cs" />

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -100,6 +100,7 @@
     <Compile Include="ISlackConnector.cs" />
     <Compile Include="Logging\ILogger.cs" />
     <Compile Include="Logging\Logger.cs" />
+    <Compile Include="Models\BotFileUpload.cs" />
     <Compile Include="Models\BotMessage.cs" />
     <Compile Include="EventHandlers\MessageReceivedEventHandler.cs" />
     <Compile Include="ISlackConnection.cs" />


### PR DESCRIPTION
Change summary:
1.  Create a FileClient that encapsulates the uploading of files
2.  FileClient supports either stream or filesystem based uploads
3.  Integration tests for each upload type
4.  Modifications to the config settings in the integration tests
