### PR TITLE
Added email property to SlackUser.

### DIFF
--- a/src/SlackConnector/Extensions/UserExtensions.cs
+++ b/src/SlackConnector/Extensions/UserExtensions.cs
@@ -11,6 +11,7 @@ namespace SlackConnector.Extensions
             {
                 Id = user.Id,
                 Name = user.Name,
+                Email = user.Profile.Email,
                 TimeZoneOffset = user.TimeZoneOffset,
                 IsBot = user.IsBot
             };

--- a/src/SlackConnector/Models/SlackUser.cs
+++ b/src/SlackConnector/Models/SlackUser.cs
@@ -4,6 +4,7 @@
     {
         public string Id { get; set; }
         public string Name { get; set; }
+        public string Email { get; set; }
 
         public string FormattedUserId
         {


### PR DESCRIPTION
This adds the users email address from Slack to the SlackUser model.

I've done this in order to make the email address available in noobot on Noobot.Core.MessagingPipeline.Request.IncomingMessage, so that it can be used by middleware/plugins.