### PR TITLE
support for updating a message, close dm chat, leave channel

### DIFF
--- a/src/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChatClientTests.cs
+++ b/src/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChatClientTests.cs
@@ -51,7 +51,7 @@ namespace SlackConnector.Tests.Unit.Connections.Clients.Flurl
             // then
             _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)));
             _httpTest
-                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChatClient.SEND_MESSAGE_PATH))
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChatClient.POST_MESSAGE_PATH))
                 .WithQueryParamValue("token", slackKey)
                 .WithQueryParamValue("channel", channel)
                 .WithQueryParamValue("text", text)
@@ -76,7 +76,7 @@ namespace SlackConnector.Tests.Unit.Connections.Clients.Flurl
 
             // then
             _httpTest
-                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChatClient.SEND_MESSAGE_PATH))
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChatClient.POST_MESSAGE_PATH))
                 .WithQueryParamValue("attachments", JsonConvert.SerializeObject(attachments))
                 .Times(1);
         }

--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -32,11 +32,16 @@ namespace SlackConnector.Tests.Unit.Stubs
             throw new NotImplementedException();
         }
 
-        public Task Say(BotMessage message)
+        public Task<string> Say(BotMessage message)
         {
             throw new NotImplementedException();
         }
-        
+
+        public Task<string> Update(BotMessage message)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<IEnumerable<SlackChatHub>> GetChannels()
         {
           throw new NotImplementedException();
@@ -81,6 +86,16 @@ namespace SlackConnector.Tests.Unit.Stubs
         }
 
         public event UserJoinedEventHandler OnUserJoined;
+        public Task CloseDirectMessageChannel(string channel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task LeaveChannel(string channel)
+        {
+            throw new NotImplementedException();
+        }
+
         public void RaiseOnUserJoined()
         {
             OnUserJoined?.Invoke(null);

--- a/src/SlackConnector/Connections/Clients/Channel/FlurlChannelClient.cs
+++ b/src/SlackConnector/Connections/Clients/Channel/FlurlChannelClient.cs
@@ -10,6 +10,8 @@ namespace SlackConnector.Connections.Clients.Channel
     {
         private readonly IResponseVerifier _responseVerifier;
         internal const string JOIN_DM_PATH = "/api/im.open";
+        internal const string CLOSE_DM_PATH = "/api/im.close";
+        internal const string LEAVE_CHANNEL_PATH = "/api/channels.leave";
         internal const string CHANNELS_LIST_PATH = "/api/channels.list";
         internal const string GROUPS_LIST_PATH = "/api/groups.list";
         internal const string USERS_LIST_PATH = "/api/users.list";
@@ -31,6 +33,32 @@ namespace SlackConnector.Connections.Clients.Channel
             _responseVerifier.VerifyResponse(response);
             return response.Channel;
         }
+
+        public async Task CloseDirectMessageChannel(string slackKey, string channel)
+        {
+            var response = await ClientConstants
+                       .SlackApiHost
+                       .AppendPathSegment(CLOSE_DM_PATH)
+                       .SetQueryParam("token", slackKey)
+                       .SetQueryParam("channel", channel)
+                       .GetJsonAsync<StandardResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+        }
+
+
+        public async Task LeaveChannel(string slackKey, string channel)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(LEAVE_CHANNEL_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("channel", channel)
+                .GetJsonAsync<StandardResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+        }
+
 
         public async Task<Models.Channel[]> GetChannels(string slackKey)
         {

--- a/src/SlackConnector/Connections/Clients/Channel/IChannelClient.cs
+++ b/src/SlackConnector/Connections/Clients/Channel/IChannelClient.cs
@@ -11,5 +11,7 @@ namespace SlackConnector.Connections.Clients.Channel
         Task<Models.Group[]> GetGroups(string slackKey);
 
         Task<Models.User[]> GetUsers(string slackKey);
+        Task CloseDirectMessageChannel(string slackKey, string channel);
+        Task LeaveChannel(string slackKey, string channel);
     }
 }

--- a/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
@@ -6,6 +6,25 @@ namespace SlackConnector.Connections.Clients.Chat
 {
     internal interface IChatClient
     {
-        Task PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="slackKey"></param>
+        /// <param name="channel"></param>
+        /// <param name="text"></param>
+        /// <param name="attachments"></param>
+        /// <returns>message ID/timestamp, for example: 123456789.9875</returns>
+        Task<string> PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
+
+        /// <summary>
+        /// Updates previously posted message
+        /// </summary>
+        /// <param name="slackKey"></param>
+        /// <param name="timeStamp">Required: timestamp of message to update, e.g. 123456789.9875</param>
+        /// <param name="channel"></param>
+        /// <param name="text"></param>
+        /// <param name="attachments"></param>
+        /// <returns>message ID/timestamp, for example: 123456789.9875</returns>
+        Task<string> UpdateMessage(string slackKey, string timeStamp, string channel, string text, IList<SlackAttachment> attachments);
     }
 }

--- a/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
+++ b/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
@@ -11,7 +11,8 @@ namespace SlackConnector.Connections.Clients
         {
             if (!response.Ok)
             {
-                throw new CommunicationException($"Error occured while posting message '{response.Error}', needed='{response.Needed}'");
+                string neededMsg = response.Needed!=null?  $", needed:'{response.Needed}'" : string.Empty;
+                throw new CommunicationException($"Error occured while posting message '{response.Error}'{neededMsg}");
             }
         }
     }

--- a/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
+++ b/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
@@ -11,7 +11,7 @@ namespace SlackConnector.Connections.Clients
         {
             if (!response.Ok)
             {
-                throw new CommunicationException($"Error occured while posting message '{response.Error}'");
+                throw new CommunicationException($"Error occured while posting message '{response.Error}', needed='{response.Needed}'");
             }
         }
     }

--- a/src/SlackConnector/Connections/Responses/JoinChannelResponse.cs
+++ b/src/SlackConnector/Connections/Responses/JoinChannelResponse.cs
@@ -4,6 +4,6 @@ namespace SlackConnector.Connections.Responses
 {
     internal class JoinChannelResponse : StandardResponse
     {
-        public Channel Channel { get; set; }
+        public new Channel Channel { get; set; }
     }
 }

--- a/src/SlackConnector/Connections/Responses/StandardResponse.cs
+++ b/src/SlackConnector/Connections/Responses/StandardResponse.cs
@@ -4,5 +4,12 @@
     {
         public bool Ok { get; set; }
         public string Error { get; set; }
+
+        /// <summary>
+        /// timestamp
+        /// </summary>
+        public string Ts { get; set; }
+        public string Channel { get; set; }
+
     }
 }

--- a/src/SlackConnector/Connections/Responses/StandardResponse.cs
+++ b/src/SlackConnector/Connections/Responses/StandardResponse.cs
@@ -11,5 +11,7 @@
         public string Ts { get; set; }
         public string Channel { get; set; }
 
+        public string Needed { get; set; }
+
     }
 }

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
@@ -21,5 +21,14 @@ namespace SlackConnector.Connections.Sockets.Messages.Inbound
 
         [JsonProperty("ts")]
         public double TimeStamp { get; set; }
+
+        /// <summary>
+        /// in case there is an update of a message, the original message will be stored here
+        /// </summary>
+        [JsonProperty("message")]
+        public ChatMessage UpdatedMessage { get; set; }
+
+        [JsonProperty("previous_message")]
+        public ChatMessage PreviousMessage { get; set; }
     }
 }

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -123,5 +123,7 @@ namespace SlackConnector
         /// </summary>
         event UserJoinedEventHandler OnUserJoined;
 
+        Task CloseDirectMessageChannel(string channel);
+        Task LeaveChannel(string channel);
     }
 }

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -56,8 +56,15 @@ namespace SlackConnector
         /// <summary>
         /// Send message to Slack channel.
         /// </summary>
-        Task Say(BotMessage message);
-        
+        Task<string> Say(BotMessage message);
+
+        /// <summary>
+        /// Update previously posted message on slack
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns></returns>
+        Task<string> Update(BotMessage message);
+
         /// <summary>
         /// Uploads a file from to a Slack channel
         /// </summary>
@@ -115,5 +122,6 @@ namespace SlackConnector
         /// Raised when a new user joins the team
         /// </summary>
         event UserJoinedEventHandler OnUserJoined;
+
     }
 }

--- a/src/SlackConnector/Models/BotMessage.cs
+++ b/src/SlackConnector/Models/BotMessage.cs
@@ -8,6 +8,11 @@ namespace SlackConnector.Models
         public SlackChatHub ChatHub { get; set; }
         public string Text { get; set; }
 
+        /// <summary>
+        /// message timestamp for updating an existing message
+        /// </summary>
+        public string Ts { get; set; }
+
         public BotMessage()
         {
             Attachments = new List<SlackAttachment>();

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -160,7 +160,7 @@ namespace SlackConnector
             }
         }
 
-        public async Task Say(BotMessage message)
+        public async Task<string> Say(BotMessage message)
         {
             if (string.IsNullOrEmpty(message.ChatHub?.Id))
             {
@@ -168,7 +168,25 @@ namespace SlackConnector
             }
 
             var client = _connectionFactory.CreateChatClient();
-            await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
+            var ts = await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
+            return ts;
+        }
+
+        public async Task<string> Update(BotMessage message)
+        {
+            if (string.IsNullOrEmpty(message.Ts))
+            {
+                throw new MissingChannelException("When calling the Update() method, the message parameter must have its Ts (timestamp) property set.");
+            }
+
+            if (string.IsNullOrEmpty(message.ChatHub?.Id))
+            {
+                throw new MissingChannelException("When calling the Update() method, the message parameter must have its ChatHub property set.");
+            }
+
+            var client = _connectionFactory.CreateChatClient();
+            var ts = await client.UpdateMessage(SlackKey, message.Ts, message.ChatHub.Id, message.Text, message.Attachments);
+            return ts;
         }
 
         public async Task Upload(SlackChatHub chatHub, string filePath)


### PR DESCRIPTION
(Simon, please let me know if any comments whatsoever and if need me to change/delete add anything)

* added support for message update (chat.update)
* added support for im.close and challens.leave (though they didn't seem to work for bots, perhaps slack will fix that in the future)
* added 'needed' attribute to StandardResponse for visibility of a missing credentials
* added UpdatedMessage (attr=message) attribute to ChatMessage event to enable tracking of updated messages. This allows to respond/handle messages resulting from updates to misspelled handlers once user fixes them via message edit feature.