### PR TITLE
Added a DeleteMessage call

### DIFF
--- a/src/SlackConnector.Tests.Integration/SayTests.cs
+++ b/src/SlackConnector.Tests.Integration/SayTests.cs
@@ -23,9 +23,35 @@ namespace SlackConnector.Tests.Integration
             };
             
             // when
-            await connection.Say(message);
+            var response = await connection.Say(message);
 
             // then
+            Assert.That(string.CompareOrdinal(response.Message.Text, message.Text) == 0, Is.True);
+        }
+
+        [Test]
+        public async Task should_say_something_on_channel_then_delete_it()
+        {
+            // given
+            var config = new ConfigReader().GetConfig();
+
+            var slackConnector = new SlackConnector();
+            var connection = await slackConnector.Connect(config.Slack.ApiToken);
+            var message = new BotMessage
+            {
+                Text = "Test delete this text for INT test",
+                ChatHub = connection.ConnectedChannel(config.Slack.TestChannel)
+            };
+
+            // when
+            var messageResponse = await connection.Say(message);
+            // Wait for 2 seconds for dramatic pause
+            await Task.Delay(2000);
+            // Now delete
+            var deleteResponse = await connection.DeleteMessage(messageResponse.Channel, messageResponse.Message.TimeStamp);
+
+            // then
+            Assert.That(deleteResponse.Channel == message.ChatHub.Id, Is.True);
         }
     }
 }

--- a/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/src/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -31,8 +31,13 @@ namespace SlackConnector.Tests.Unit.Stubs
         {
             throw new NotImplementedException();
         }
-
-        public Task Say(BotMessage message)
+        
+        Task<SlackMessagePosted> ISlackConnection.Say(BotMessage message)
+        {
+            throw new NotImplementedException();
+        }
+        
+        public Task<SlackMessageDeleted> DeleteMessage(string channel, string timeStamp)
         {
             throw new NotImplementedException();
         }

--- a/src/SlackConnector/Connections/Clients/Chat/FlurlChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/FlurlChatClient.cs
@@ -13,13 +13,14 @@ namespace SlackConnector.Connections.Clients.Chat
     {
         private readonly IResponseVerifier _responseVerifier;
         internal const string SEND_MESSAGE_PATH = "/api/chat.postMessage";
+        internal const string DELETE_MESSAGE_PATH = "/api/chat.delete";
 
         public FlurlChatClient(IResponseVerifier responseVerifier)
         {
             _responseVerifier = responseVerifier;
         }
 
-        public async Task PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments)
+        public async Task<PostMessageResponse> PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments)
         {
             var request = ClientConstants
                        .SlackApiHost
@@ -28,14 +29,30 @@ namespace SlackConnector.Connections.Clients.Chat
                        .SetQueryParam("channel", channel)
                        .SetQueryParam("text", text)
                        .SetQueryParam("as_user", "true");
-            
+
             if (attachments != null && attachments.Any())
             {
                 request.SetQueryParam("attachments", JsonConvert.SerializeObject(attachments));
             }
 
-            var response = await request.GetJsonAsync<StandardResponse>();
+            var response = await request.GetJsonAsync<PostMessageResponse>();
             _responseVerifier.VerifyResponse(response);
+            return response;
+        }
+
+        public async Task<DeleteMessageResponse> DeleteMessage(string slackKey, string channel, string timeStamp)
+        {
+            var request = ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(DELETE_MESSAGE_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("channel", channel)
+                .SetQueryParam("ts", timeStamp)
+                .SetQueryParam("as_user", "true");
+
+            var response = await request.GetJsonAsync<DeleteMessageResponse>();
+            _responseVerifier.VerifyResponse(response);
+            return response;
         }
     }
 }

--- a/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
+++ b/src/SlackConnector/Connections/Clients/Chat/IChatClient.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using SlackConnector.Connections.Responses;
 using SlackConnector.Models;
 
 namespace SlackConnector.Connections.Clients.Chat
 {
     internal interface IChatClient
     {
-        Task PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
+        Task<PostMessageResponse> PostMessage(string slackKey, string channel, string text, IList<SlackAttachment> attachments);
+	    Task<DeleteMessageResponse> DeleteMessage(string slackKey, string channel, string timeStamp);
     }
 }

--- a/src/SlackConnector/Connections/Responses/DeleteMessageResponse.cs
+++ b/src/SlackConnector/Connections/Responses/DeleteMessageResponse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SlackConnector.Connections.Responses
+{
+    internal class DeleteMessageResponse : StandardResponse
+    {
+        [JsonProperty("ts")]
+        public string TimeStamp { get; set; }
+
+        public string Channel { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Responses/MessageObjectResponse.cs
+++ b/src/SlackConnector/Connections/Responses/MessageObjectResponse.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SlackConnector.Connections.Responses
+{
+    public class MessageObjectResponse
+    {
+        public string Type { get; set; }
+        
+        public string User { get; set; }
+        
+        public string Text { get; set; }
+
+        [JsonProperty("bot_id")]
+        public string BotId { get; set; }
+
+        [JsonProperty("ts")]
+        public string TimeStamp { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Responses/PostMessageResponse.cs
+++ b/src/SlackConnector/Connections/Responses/PostMessageResponse.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+
+namespace SlackConnector.Connections.Responses
+{
+    internal class PostMessageResponse : StandardResponse
+    {
+        [JsonProperty("ts")]
+        public double TimeStamp { get; set; }
+
+        public string Channel { get; set; }
+
+        /// <summary>
+        /// Message object, as it was parsed by Slack servers
+        /// </summary>
+        public MessageObjectResponse Message { get; set; }
+    }
+}

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -56,8 +56,13 @@ namespace SlackConnector
         /// <summary>
         /// Send message to Slack channel.
         /// </summary>
-        Task Say(BotMessage message);
-        
+        Task<SlackMessagePosted> Say(BotMessage message);
+
+        /// <summary>
+        /// Delete message from Slack channel.
+        /// </summary>
+        Task<SlackMessageDeleted> DeleteMessage(string channel, string timeStamp);
+
         /// <summary>
         /// Uploads a file from to a Slack channel
         /// </summary>

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -57,10 +57,13 @@ namespace SlackConnector
         /// Send message to Slack channel.
         /// </summary>
         Task<SlackMessagePosted> Say(BotMessage message);
-
+        
         /// <summary>
         /// Delete message from Slack channel.
         /// </summary>
+        /// <param name="channel">channel is used to locate a particular message with a timeStamp</param>
+        /// <param name="timeStamp">timStamp is used to identify a message instance</param>
+        /// <returns></returns>
         Task<SlackMessageDeleted> DeleteMessage(string channel, string timeStamp);
 
         /// <summary>

--- a/src/SlackConnector/Models/SlackMessageDeleted.cs
+++ b/src/SlackConnector/Models/SlackMessageDeleted.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackConnector.Models
+{
+    public class SlackMessageDeleted
+    {
+        public string TimeStamp { get; set; }
+
+        public string Channel { get; set; }
+    }
+}

--- a/src/SlackConnector/Models/SlackMessagePosted.cs
+++ b/src/SlackConnector/Models/SlackMessagePosted.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SlackConnector.Connections.Responses;
+
+namespace SlackConnector.Models
+{
+    public class SlackMessagePosted
+    {
+        public double TimeStamp { get; set; }
+
+        public string Channel { get; set; }
+
+        /// <summary>
+        /// Message object, as it was parsed by Slack servers
+        /// </summary>
+        public MessageObjectResponse Message { get; set; }
+    }
+}

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -170,7 +170,9 @@ namespace SlackConnector
             var client = _connectionFactory.CreateChatClient();
             var response = await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
             if (response == null)
+            {
                 return null;
+            }
             return new SlackMessagePosted() { TimeStamp = response.TimeStamp, Channel = response.Channel, Message = response.Message };
         }
         
@@ -179,7 +181,9 @@ namespace SlackConnector
             var client = _connectionFactory.CreateChatClient();
             var response = await client.DeleteMessage(SlackKey, channel, timeStamp);
             if (response == null)
+            {
                 return null;
+            }
             return new SlackMessageDeleted() { TimeStamp = response.TimeStamp, Channel = response.Channel };
         }
 

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -169,6 +169,8 @@ namespace SlackConnector
 
             var client = _connectionFactory.CreateChatClient();
             var response = await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
+            if (response == null)
+                return null;
             return new SlackMessagePosted() { TimeStamp = response.TimeStamp, Channel = response.Channel, Message = response.Message };
         }
         
@@ -176,6 +178,8 @@ namespace SlackConnector
         {
             var client = _connectionFactory.CreateChatClient();
             var response = await client.DeleteMessage(SlackKey, channel, timeStamp);
+            if (response == null)
+                return null;
             return new SlackMessageDeleted() { TimeStamp = response.TimeStamp, Channel = response.Channel };
         }
 

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -160,7 +160,7 @@ namespace SlackConnector
             }
         }
 
-        public async Task Say(BotMessage message)
+        public async Task<SlackMessagePosted> Say(BotMessage message)
         {
             if (string.IsNullOrEmpty(message.ChatHub?.Id))
             {
@@ -168,7 +168,15 @@ namespace SlackConnector
             }
 
             var client = _connectionFactory.CreateChatClient();
-            await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
+            var response = await client.PostMessage(SlackKey, message.ChatHub.Id, message.Text, message.Attachments);
+            return new SlackMessagePosted() { TimeStamp = response.TimeStamp, Channel = response.Channel, Message = response.Message };
+        }
+        
+        public async Task<SlackMessageDeleted> DeleteMessage(string channel, string timeStamp)
+        {
+            var client = _connectionFactory.CreateChatClient();
+            var response = await client.DeleteMessage(SlackKey, channel, timeStamp);
+            return new SlackMessageDeleted() { TimeStamp = response.TimeStamp, Channel = response.Channel };
         }
 
         public async Task Upload(SlackChatHub chatHub, string filePath)

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -120,10 +120,13 @@
     <Compile Include="Connections\Models\Group.cs" />
     <Compile Include="Connections\ProxySettings.cs" />
     <Compile Include="Connections\Responses\ChannelsResponse.cs" />
+    <Compile Include="Connections\Responses\DeleteMessageResponse.cs" />
     <Compile Include="Connections\Responses\GroupsResponse.cs" />
     <Compile Include="Connections\Responses\JoinChannelResponse.cs" />
     <Compile Include="Connections\Models\Profile.cs" />
     <Compile Include="Connections\IConnectionFactory.cs" />
+    <Compile Include="Connections\Responses\MessageObjectResponse.cs" />
+    <Compile Include="Connections\Responses\PostMessageResponse.cs" />
     <Compile Include="Connections\Responses\StandardResponse.cs" />
     <Compile Include="Connections\Responses\UsersResponse.cs" />
     <Compile Include="Connections\Sockets\Messages\Inbound\DmChannelJoinedMessage.cs" />
@@ -162,6 +165,8 @@
     <Compile Include="Models\SlackAttachmentAction.cs" />
     <Compile Include="Models\SlackAttachmentActionStyle.cs" />
     <Compile Include="Models\SlackAttachmentStatics.cs" />
+    <Compile Include="Models\SlackMessageDeleted.cs" />
+    <Compile Include="Models\SlackMessagePosted.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Models\SlackAttachment.cs" />
     <Compile Include="Models\SlackAttachmentField.cs" />


### PR DESCRIPTION
I've added a Delete message call.

I had to modify the Say call to return the correct timestamp from the slack server to be able to call the DeleteMessage.

I also had to change the Timestamp type from double to string to ensure the timestamp value was kept correctly. Using double for this value meant that accuracy came into play, slightly adjusting the value and when I passed this back to Slack, it couldn't actually find the message.

Using a string allowed me to keep the exact value.