### PR TITLE
F/new channel methods

### DIFF
--- a/src/SlackConnector/Connections/Clients/Channel/FlurlChannelClient.cs
+++ b/src/SlackConnector/Connections/Clients/Channel/FlurlChannelClient.cs
@@ -10,6 +10,11 @@ namespace SlackConnector.Connections.Clients.Channel
     {
         private readonly IResponseVerifier _responseVerifier;
         internal const string JOIN_DM_PATH = "/api/im.open";
+        internal const string CHANNEL_CREATE_PATH = "/api/channels.create";
+        internal const string CHANNEL_JOIN_PATH = "/api/channels.join";
+        internal const string CHANNEL_ARCHIVE_PATH = "/api/channels.archive";
+        internal const string CHANNEL_SET_PURPOSE_PATH = "/api/channels.setPurpose";
+        internal const string CHANNEL_SET_TOPIC_PATH = "/api/channels.setTopic";
         internal const string CHANNELS_LIST_PATH = "/api/channels.list";
         internal const string GROUPS_LIST_PATH = "/api/groups.list";
         internal const string USERS_LIST_PATH = "/api/users.list";
@@ -30,6 +35,72 @@ namespace SlackConnector.Connections.Clients.Channel
 
             _responseVerifier.VerifyResponse(response);
             return response.Channel;
+        }
+
+        public async Task<Models.Channel> CreateChannel(string slackKey, string channelName)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(CHANNEL_CREATE_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("name", channelName)
+                .GetJsonAsync<ChannelResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+            return response.Channel;
+        }
+
+        public async Task<Models.Channel> JoinChannel(string slackKey, string channelName)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(CHANNEL_JOIN_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("name", channelName)
+                .GetJsonAsync<ChannelResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+            return response.Channel;
+        }
+
+        public async Task ArchiveChannel(string slackKey, string channelName)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(CHANNEL_ARCHIVE_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("channel", channelName)
+                .GetJsonAsync<StandardResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+        }
+
+        public async Task<string> SetPurpose(string slackKey, string channelName, string purpose)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(CHANNEL_SET_PURPOSE_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("channel", channelName)
+                .SetQueryParam("purpose", purpose)
+                .GetJsonAsync<PurposeResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+            return response.Purpose;
+        }
+
+        public async Task<string> SetTopic(string slackKey, string channelName, string topic)
+        {
+            var response = await ClientConstants
+                .SlackApiHost
+                .AppendPathSegment(CHANNEL_SET_TOPIC_PATH)
+                .SetQueryParam("token", slackKey)
+                .SetQueryParam("channel", channelName)
+                .SetQueryParam("topic", topic)
+                .GetJsonAsync<TopicResponse>();
+
+            _responseVerifier.VerifyResponse(response);
+            return response.Topic;
         }
 
         public async Task<Models.Channel[]> GetChannels(string slackKey)

--- a/src/SlackConnector/Connections/Clients/Channel/IChannelClient.cs
+++ b/src/SlackConnector/Connections/Clients/Channel/IChannelClient.cs
@@ -1,10 +1,21 @@
 ﻿using System.Threading.Tasks;
+using SlackConnector.Connections.Responses;
 
 namespace SlackConnector.Connections.Clients.Channel
 {
     internal interface IChannelClient
     {
         Task<Models.Channel> JoinDirectMessageChannel(string slackKey, string user);
+
+        Task<Models.Channel> CreateChannel(string slackKey, string channelName);
+
+        Task<Models.Channel> JoinChannel(string slackKey, string channelName);
+
+        Task ArchiveChannel(string slackKey, string channelName);
+
+        Task<string> SetPurpose(string slackKey, string channelName, string purpose);
+
+        Task<string> SetTopic(string slackKey, string channelName, string topic);
 
         Task<Models.Channel[]> GetChannels(string slackKey);
 

--- a/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
+++ b/src/SlackConnector/Connections/Clients/ResponseVerifier.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Newtonsoft.Json;
 using SlackConnector.Connections.Responses;
 using SlackConnector.Exceptions;
 

--- a/src/SlackConnector/Connections/Responses/ChannelResponse.cs
+++ b/src/SlackConnector/Connections/Responses/ChannelResponse.cs
@@ -1,0 +1,9 @@
+﻿using SlackConnector.Connections.Models;
+
+namespace SlackConnector.Connections.Responses
+{
+    internal class ChannelResponse : StandardResponse
+    {
+        public Channel Channel { get; set; }
+    }
+}

--- a/src/SlackConnector/Connections/Responses/PurposeResponse.cs
+++ b/src/SlackConnector/Connections/Responses/PurposeResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SlackConnector.Connections.Responses
+{
+	internal class PurposeResponse : StandardResponse
+	{
+		public string Purpose { get; set; }
+	}
+}

--- a/src/SlackConnector/Connections/Responses/TopicResponse.cs
+++ b/src/SlackConnector/Connections/Responses/TopicResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SlackConnector.Connections.Responses
+{
+    internal class TopicResponse : StandardResponse
+    {
+        public string Topic { get; set; }
+    }
+}

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -86,10 +86,35 @@ namespace SlackConnector
         /// <returns>Users.</returns>
         Task<IEnumerable<SlackUser>> GetUsers();
 
-            /// <summary>
+        /// <summary>
         /// Opens a DM channel to a user. Required to PM someone.
         /// </summary>
         Task<SlackChatHub> JoinDirectMessageChannel(string user);
+
+        /// <summary>
+        /// Creates a channel.
+        /// </summary>
+        Task<SlackChatHub> JoinChannel(string channelName);
+
+        /// <summary>
+        /// Joins a channel.
+        /// </summary>
+        Task<SlackChatHub> CreateChannel(string channelName);
+
+        /// <summary>
+        /// Archives a channel.
+        /// </summary>
+        Task ArchiveChannel(string channelName);
+
+        /// <summary>
+        /// Sets a channel purpose.
+        /// </summary>
+        Task<SlackPurpose> SetChannelPurpose(string channelName, string purpose);
+
+        /// <summary>
+        /// Sets a channel topic.
+        /// </summary>
+        Task<SlackTopic> SetChannelTopic(string channelName, string topic);
 
         /// <summary>
         /// Indicate to the users on the channel that the bot is 'typing' on the keyboard.

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -92,12 +92,12 @@ namespace SlackConnector
         Task<SlackChatHub> JoinDirectMessageChannel(string user);
 
         /// <summary>
-        /// Creates a channel.
+        /// Joins a channel.
         /// </summary>
         Task<SlackChatHub> JoinChannel(string channelName);
 
         /// <summary>
-        /// Joins a channel.
+        /// Create a channel.
         /// </summary>
         Task<SlackChatHub> CreateChannel(string channelName);
 

--- a/src/SlackConnector/Models/SlackPurpose.cs
+++ b/src/SlackConnector/Models/SlackPurpose.cs
@@ -1,0 +1,11 @@
+﻿namespace SlackConnector.Models
+{
+    /// <summary>
+    /// This represents the purpose value of the requested channel.
+    /// </summary>
+    public class SlackPurpose
+    {
+        public string ChannelName { get; set; }
+        public string Purpose { get; set; }
+    }
+}

--- a/src/SlackConnector/Models/SlackTopic.cs
+++ b/src/SlackConnector/Models/SlackTopic.cs
@@ -1,0 +1,11 @@
+﻿namespace SlackConnector.Models
+{
+    /// <summary>
+    /// This represents the topic value of the requested channel.
+    /// </summary>
+    public class SlackTopic
+    {
+        public string ChannelName { get; set; }
+        public string Topic { get; set; }
+    }
+}

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -256,6 +256,97 @@ namespace SlackConnector
             };
         }
 
+        public async Task<SlackChatHub> JoinChannel(string channelName)
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                throw new ArgumentNullException(nameof(channelName));
+            }
+
+            IChannelClient client = _connectionFactory.CreateChannelClient();
+            Channel channel = await client.JoinChannel(SlackKey, channelName);
+
+            return new SlackChatHub
+            {
+                Id = channel.Id,
+                Name = channel.Name,
+                Type = SlackChatHubType.Channel
+            };
+        }
+
+        public async Task<SlackChatHub> CreateChannel(string channelName)
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                throw new ArgumentNullException(nameof(channelName));
+            }
+
+            IChannelClient client = _connectionFactory.CreateChannelClient();
+            Channel channel = await client.CreateChannel(SlackKey, channelName);
+
+            return new SlackChatHub
+            {
+                Id = channel.Id,
+                Name = channel.Name,
+                Type = SlackChatHubType.Channel
+            };
+        }
+
+        public async Task ArchiveChannel(string channelName)
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                throw new ArgumentNullException(nameof(channelName));
+            }
+
+            IChannelClient client = _connectionFactory.CreateChannelClient();
+            await client.ArchiveChannel(SlackKey, channelName);
+        }
+
+        public async Task<SlackPurpose> SetChannelPurpose(string channelName, string purpose)
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                throw new ArgumentNullException(nameof(channelName));
+            }
+
+            if (string.IsNullOrEmpty(purpose))
+            {
+                throw new ArgumentNullException(nameof(purpose));
+            }
+
+            IChannelClient client = _connectionFactory.CreateChannelClient();
+            string purposeSet = await client.SetPurpose(SlackKey, channelName, purpose);
+
+            return new SlackPurpose
+            {
+                ChannelName = channelName,
+                Purpose = purposeSet
+            };
+        }
+
+        public async Task<SlackTopic> SetChannelTopic(string channelName, string topic)
+        {
+            if (string.IsNullOrEmpty(channelName))
+            {
+                throw new ArgumentNullException(nameof(channelName));
+            }
+
+            if (string.IsNullOrEmpty(topic))
+            {
+                throw new ArgumentNullException(nameof(topic));
+            }
+
+            IChannelClient client = _connectionFactory.CreateChannelClient();
+            string topicSet = await client.SetTopic(SlackKey, channelName, topic);
+
+            return new SlackTopic
+            {
+                ChannelName = channelName,
+                Topic = topicSet
+            };
+        }
+
         public async Task IndicateTyping(SlackChatHub chatHub)
         {
             var message = new TypingIndicatorMessage

--- a/tests/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChannelClientTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChannelClientTests.cs
@@ -143,15 +143,7 @@ namespace SlackConnector.Tests.Unit.Connections.Clients.Flurl
             _httpTest.RespondWithJson(expectedResponse);
 
             // when
-            var result = true;
-            try
-            {
-                await _channelClient.ArchiveChannel(slackKey, channelName);
-            }
-            catch (Exception)
-            {
-                result = false;
-            }
+            await _channelClient.ArchiveChannel(slackKey, channelName);
 
             // then
             _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
@@ -160,8 +152,6 @@ namespace SlackConnector.Tests.Unit.Connections.Clients.Flurl
                 .WithQueryParamValue("token", slackKey)
                 .WithQueryParamValue("channel", channelName)
                 .Times(1);
-
-            result.ShouldBe(true);
         }
 
         [Fact]

--- a/tests/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChannelClientTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Connections/Clients/Flurl/FlurlChannelClientTests.cs
@@ -4,6 +4,7 @@ using ExpectedObjects;
 using Flurl;
 using Flurl.Http.Testing;
 using Moq;
+using Shouldly;
 using SlackConnector.Connections.Clients;
 using SlackConnector.Connections.Clients.Channel;
 using SlackConnector.Connections.Models;
@@ -61,6 +62,166 @@ namespace SlackConnector.Tests.Unit.Connections.Clients.Flurl
                 .Times(1);
 
             result.ToExpectedObject().ShouldEqual(expectedResponse.Channel);
+        }
+
+        [Fact]
+        public async Task should_create_channel()
+        {
+            // given
+            const string slackKey = "I-is-another-key";
+            const string channelName = "my-channel";
+
+            var expectedResponse = new ChannelResponse()
+            {
+                Channel = new Channel
+                {
+                    Id = "some-channel",
+                    IsChannel = true
+                }
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // when
+            var result = await _channelClient.CreateChannel(slackKey, channelName);
+
+            // then
+            _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
+            _httpTest
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChannelClient.CHANNEL_CREATE_PATH))
+                .WithQueryParamValue("token", slackKey)
+                .WithQueryParamValue("name", channelName)
+                .Times(1);
+
+            result.ToExpectedObject().ShouldEqual(expectedResponse.Channel);
+        }
+
+        [Fact]
+        public async Task should_join_channel()
+        {
+            // given
+            const string slackKey = "I-is-another-key";
+            const string channelName = "my-channel";
+
+            var expectedResponse = new ChannelResponse()
+            {
+                Channel = new Channel
+                {
+                    Id = "some-channel",
+                    IsChannel = true
+                }
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // when
+            var result = await _channelClient.JoinChannel(slackKey, channelName);
+
+            // then
+            _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
+            _httpTest
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChannelClient.CHANNEL_JOIN_PATH))
+                .WithQueryParamValue("token", slackKey)
+                .WithQueryParamValue("name", channelName)
+                .Times(1);
+
+            result.ToExpectedObject().ShouldEqual(expectedResponse.Channel);
+        }
+
+        [Fact]
+        public async Task should_archive_channel()
+        {
+            // given
+            const string slackKey = "I-is-another-key";
+            const string channelName = "my-channel";
+
+            var expectedResponse = new StandardResponse()
+            {
+                Ok = true
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // when
+            var result = true;
+            try
+            {
+                await _channelClient.ArchiveChannel(slackKey, channelName);
+            }
+            catch (Exception)
+            {
+                result = false;
+            }
+
+            // then
+            _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
+            _httpTest
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChannelClient.CHANNEL_ARCHIVE_PATH))
+                .WithQueryParamValue("token", slackKey)
+                .WithQueryParamValue("channel", channelName)
+                .Times(1);
+
+            result.ShouldBe(true);
+        }
+
+        [Fact]
+        public async Task should_set_channel_purpose()
+        {
+            // given
+            const string slackKey = "I-is-another-key";
+            const string channelName = "my-channel";
+            const string channelPurpose = "my purpose";
+
+            var expectedResponse = new PurposeResponse()
+            {
+                Purpose = channelPurpose
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // when
+            var result = await _channelClient.SetPurpose(slackKey, channelName, channelPurpose);
+
+            // then
+            _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
+            _httpTest
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChannelClient.CHANNEL_SET_PURPOSE_PATH))
+                .WithQueryParamValue("token", slackKey)
+                .WithQueryParamValue("channel", channelName)
+                .WithQueryParamValue("purpose", channelPurpose)
+                .Times(1);
+
+            result.ToExpectedObject().ShouldEqual(expectedResponse.Purpose);
+        }
+
+        [Fact]
+        public async Task should_set_channel_topic()
+        {
+            // given
+            const string slackKey = "I-is-another-key";
+            const string channelName = "my-channel";
+            const string channelTopic = "my topic";
+
+            var expectedResponse = new TopicResponse()
+            {
+                Topic = channelTopic
+            };
+
+            _httpTest.RespondWithJson(expectedResponse);
+
+            // when
+            var result = await _channelClient.SetTopic(slackKey, channelName, channelTopic);
+
+            // then
+            _responseVerifierMock.Verify(x => x.VerifyResponse(Looks.Like(expectedResponse)), Times.Once);
+            _httpTest
+                .ShouldHaveCalled(ClientConstants.SlackApiHost.AppendPathSegment(FlurlChannelClient.CHANNEL_SET_TOPIC_PATH))
+                .WithQueryParamValue("token", slackKey)
+                .WithQueryParamValue("channel", channelName)
+                .WithQueryParamValue("topic", channelTopic)
+                .Times(1);
+
+            result.ToExpectedObject().ShouldEqual(expectedResponse.Topic);
         }
 
         [Fact]

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/ArchiveChannelTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/ArchiveChannelTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using Ploeh.AutoFixture.Xunit2;
+using SlackConnector.Connections;
+using SlackConnector.Connections.Clients.Channel;
+using SlackConnector.Connections.Models;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using SlackConnector.Tests.Unit.TestExtensions;
+using Xunit;
+using Shouldly;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class ArchiveChannelTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_be_successful(
+            [Frozen]Mock<IConnectionFactory> connectionFactory,
+            Mock<IChannelClient> channelClient, 
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            const string slackKey = "key-yay";
+            const string channelName = "public-channel-name";
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            connectionFactory
+                .Setup(x => x.CreateChannelClient())
+                .Returns(channelClient.Object);
+
+            // when
+             await slackConnection.ArchiveChannel(channelName);
+
+            // then
+            channelClient.Verify(x => x.ArchiveChannel(slackKey, channelName), Times.Once);
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_channel_name(
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.ArchiveChannel(null));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_channel_name(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.ArchiveChannel(string.Empty));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/CreateChannelTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/CreateChannelTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using Ploeh.AutoFixture.Xunit2;
+using SlackConnector.Connections;
+using SlackConnector.Connections.Clients.Channel;
+using SlackConnector.Connections.Models;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using SlackConnector.Tests.Unit.TestExtensions;
+using Xunit;
+using Shouldly;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class CreateChannelTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_return_expected_slack_hub(
+            [Frozen]Mock<IConnectionFactory> connectionFactory,
+            Mock<IChannelClient> channelClient, 
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            const string slackKey = "key-yay";
+            const string channelName = "public-channel-name";
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            connectionFactory
+                .Setup(x => x.CreateChannelClient())
+                .Returns(channelClient.Object);
+
+            var returnChannel = new Channel { Id = "super-id", Name = "public-channel-name" };
+            channelClient
+                .Setup(x => x.CreateChannel(slackKey, channelName))
+                .ReturnsAsync(returnChannel);
+
+            // when
+            var result = await slackConnection.CreateChannel(channelName);
+
+            // then
+            result.ShouldLookLike(new SlackChatHub
+            {
+                Id = returnChannel.Id,
+                Name = returnChannel.Name,
+                Type = SlackChatHubType.Channel
+            });
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_channel_name(
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.CreateChannel(null));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_channel_name(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.CreateChannel(string.Empty));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/JoinChannelTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/JoinChannelTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using Ploeh.AutoFixture.Xunit2;
+using SlackConnector.Connections;
+using SlackConnector.Connections.Clients.Channel;
+using SlackConnector.Connections.Models;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using SlackConnector.Tests.Unit.TestExtensions;
+using Xunit;
+using Shouldly;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class JoinChannelTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_return_expected_slack_hub(
+            [Frozen]Mock<IConnectionFactory> connectionFactory,
+            Mock<IChannelClient> channelClient, 
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            const string slackKey = "key-yay";
+            const string channelName = "public-channel-name";
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            connectionFactory
+                .Setup(x => x.CreateChannelClient())
+                .Returns(channelClient.Object);
+
+            var returnChannel = new Channel { Id = "super-id", Name = "public-channel-name" };
+            channelClient
+                .Setup(x => x.JoinChannel(slackKey, channelName))
+                .ReturnsAsync(returnChannel);
+
+            // when
+            var result = await slackConnection.JoinChannel(channelName);
+
+            // then
+            result.ShouldLookLike(new SlackChatHub
+            {
+                Id = returnChannel.Id,
+                Name = returnChannel.Name,
+                Type = SlackChatHubType.Channel
+            });
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_channel_name(
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.JoinChannel(null));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_channel_name(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.JoinChannel(string.Empty));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/SetChannelPurposeTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/SetChannelPurposeTests.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using Ploeh.AutoFixture.Xunit2;
+using SlackConnector.Connections;
+using SlackConnector.Connections.Clients.Channel;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using SlackConnector.Tests.Unit.TestExtensions;
+using Xunit;
+using Shouldly;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class SetChannelPurposeTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_return_expected_slack_purpose(
+            [Frozen]Mock<IConnectionFactory> connectionFactory,
+            Mock<IChannelClient> channelClient, 
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            const string slackKey = "key-yay";
+            const string channelName = "public-channel-name";
+            const string channelPurpose = "new purpose";
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            connectionFactory
+                .Setup(x => x.CreateChannelClient())
+                .Returns(channelClient.Object);
+
+            channelClient
+                .Setup(x => x.SetPurpose(slackKey, channelName, channelPurpose))
+                .ReturnsAsync(channelPurpose);
+
+            // when
+            var result = await slackConnection.SetChannelPurpose(channelName, channelPurpose);
+
+            // then
+            result.ShouldLookLike(new SlackPurpose
+            {
+                ChannelName = channelName,
+                Purpose = channelPurpose
+            });
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_channel_name(
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelPurpose(null, "purpose"));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_channel_name(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelPurpose(string.Empty, "purpose"));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_purpose(
+            Mock<IWebSocketClient> webSocket,
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelPurpose("channel", null));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: purpose");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_purpose(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelPurpose("channel", string.Empty));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: purpose");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/SetChannelTopicTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/SetChannelTopicTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Threading.Tasks;
+using Moq;
+using Ploeh.AutoFixture.Xunit2;
+using SlackConnector.Connections;
+using SlackConnector.Connections.Clients.Channel;
+using SlackConnector.Connections.Models;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using SlackConnector.Tests.Unit.TestExtensions;
+using Xunit;
+using Shouldly;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class SetChannelTopicTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_return_expected_slack_topic(
+            [Frozen]Mock<IConnectionFactory> connectionFactory,
+            Mock<IChannelClient> channelClient, 
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            const string slackKey = "key-yay";
+            const string channelName = "public-channel-name";
+            const string channelTopic = "new topic";
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            connectionFactory
+                .Setup(x => x.CreateChannelClient())
+                .Returns(channelClient.Object);
+
+            channelClient
+                .Setup(x => x.SetTopic(slackKey, channelName, channelTopic))
+                .ReturnsAsync(channelTopic);
+
+            // when
+            var result = await slackConnection.SetChannelTopic(channelName, channelTopic);
+
+            // then
+            result.ShouldLookLike(new SlackTopic
+            {
+                ChannelName = channelName,
+                Topic = channelTopic
+            });
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_channel_name(
+            Mock<IWebSocketClient> webSocket, 
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelTopic(null, "topic"));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_channel_name(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelTopic(string.Empty, "topic"));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: channelName");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_null_topic(
+            Mock<IWebSocketClient> webSocket,
+            SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelTopic("channel", null));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: topic");
+        }
+
+        [Theory, AutoMoqData]
+        private async Task should_throw_exception_given_empty_topic(Mock<IWebSocketClient> webSocket, SlackConnection slackConnection)
+        {
+            // given
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(() => slackConnection.SetChannelTopic("channel", string.Empty));
+
+            // then
+            exception.Message.ShouldBe("Value cannot be null.\r\nParameter name: topic");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/tests/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -51,6 +51,31 @@ namespace SlackConnector.Tests.Unit.Stubs
             throw new NotImplementedException();
         }
 
+        public async Task<SlackChatHub> JoinChannel(string channelName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SlackChatHub> CreateChannel(string channelName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task ArchiveChannel(string channelName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SlackPurpose> SetChannelPurpose(string channelName, string purpose)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SlackTopic> SetChannelTopic(string channelName, string topic)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task IndicateTyping(SlackChatHub chatHub)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
This PR adds the ability to:
- Create channel
- Join channel
- Set channel purpose
- Set channel topic
- Archive channel

All new methods have accompanying tests using the format setup already in this repo.

This PR implements the feature request in issue (feature request) #11.