### PR TITLE
Added support for link buttons

### DIFF
--- a/src/SlackConnector/Models/SlackAttachmentAction.cs
+++ b/src/SlackConnector/Models/SlackAttachmentAction.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace SlackConnector.Models
 {
@@ -19,6 +18,10 @@ namespace SlackConnector.Models
 
         [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
+
+        [JsonProperty(PropertyName = "url", NullValueHandling = NullValueHandling.Ignore)]
+        public string Url { get; set; }
+
 
         public SlackAttachmentAction()
         {

--- a/src/SlackConnector/SlackConnector.csproj
+++ b/src/SlackConnector/SlackConnector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.5;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Version>1.0.1</Version>
     <AssemblyVersion>1.0.0.1</AssemblyVersion>
     <FileVersion>1.0.0.1</FileVersion>

--- a/tests/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
@@ -1,8 +1,8 @@
-﻿using System.Text.RegularExpressions;
-using Newtonsoft.Json;
-using SlackConnector.Models;
-using Xunit;
+﻿using Newtonsoft.Json;
 using Shouldly;
+using SlackConnector.Models;
+using System.Text.RegularExpressions;
+using Xunit;
 
 namespace SlackConnector.Tests.Unit.Models
 {
@@ -52,6 +52,11 @@ namespace SlackConnector.Tests.Unit.Models
                             Name = "no",
                             Value = "nop",
                             Text = "No"
+                        },
+                        new SlackAttachmentAction
+                        {
+                            Url = "https://test.com/",
+                            Text = "LinkButton"
                         }
                     },
                     ImageUrl = "http://my-website.com/path/to/image.jpg",

--- a/tests/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
+++ b/tests/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
@@ -29,6 +29,13 @@
             "text": "No",
             "type": "button",
             "value": "nop"
+        },
+        {
+            "name": null,
+            "text": "LinkButton",
+            "type": "button",
+            "value": null,
+            "url": "https://test.com/"
         }
     ],
     "image_url": "http://my-website.com/path/to/image.jpg",


### PR DESCRIPTION
This is the functionality to fix issue #74, i.e. add support for [LinkButtons](https://api.slack.com/docs/message-attachments#link_buttons).