### PR TITLE
Receive and Download Files/Attachments

### DIFF
--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/ChatMessage.cs
@@ -18,6 +18,7 @@ namespace SlackConnector.Connections.Sockets.Messages.Inbound
         public string User { get; set; }
         public string Text { get; set; }
         public string Team { get; set; }
+        public File File { get; set; }
 
         [JsonProperty("ts")]
         public double Timestamp { get; set; }

--- a/src/SlackConnector/Connections/Sockets/Messages/Inbound/File.cs
+++ b/src/SlackConnector/Connections/Sockets/Messages/Inbound/File.cs
@@ -1,0 +1,84 @@
+﻿using Newtonsoft.Json;
+
+namespace SlackConnector.Connections.Sockets.Messages.Inbound
+{
+    internal class File
+    {
+        public string Id { get; set; }
+        public int Created { get; set; }
+        public int Timestamp { get; set; }
+        public string Name { get; set; }
+        public string Title { get; set; }
+        public string Mimetype { get; set; }
+        public string FileType { get; set; }
+
+        [JsonProperty("pretty_type")]
+        public string PrettyType { get; set; }
+
+        public string User { get; set; }
+        public bool Editable { get; set; }
+        public int Size { get; set; }
+        public string Mode { get; set; }
+
+        [JsonProperty("is_external")]
+        public bool IsExternal { get; set; }
+
+        [JsonProperty("external_type")]
+        public string ExternalType { get; set; }
+
+        [JsonProperty("is_public")]
+        public bool IsPublic { get; set; }
+
+        [JsonProperty("public_url_shared")]
+        public bool PublicUrlShared { get; set; }
+
+        [JsonProperty("display_as_bot")]
+        public bool DisplayAsBot { get; set; }
+
+        public string Username { get; set; }
+
+        [JsonProperty("url_private")]
+        public string UrlPrivate { get; set; }
+
+        [JsonProperty("url_private_download")]
+        public string UrlPrivateDownload { get; set; }
+
+        [JsonProperty("thumb_64")]
+        public string Thumb64 { get; set; }
+
+        [JsonProperty("thumb_80")]
+        public string Thumb80 { get; set; }
+
+        [JsonProperty("thumb_360")]
+        public string Thumb360 { get; set; }
+
+        [JsonProperty("thumb_360_w")]
+        public int Thumb360Width { get; set; }
+
+        [JsonProperty("thumb_360_h")]
+        public int Thumb360Height { get; set; }
+
+        [JsonProperty("thumb_160")]
+        public string Thumb160 { get; set; }
+
+        [JsonProperty("thumb_360_gif")]
+        public string Thumb360Gif { get; set; }
+
+        [JsonProperty("image_exif_rotation")]
+        public int ImageExifRotation { get; set; }
+
+        [JsonProperty("original_w")]
+        public int OriginalWidth { get; set; }
+
+        [JsonProperty("original_h")]
+        public int OriginalHeight { get; set; }
+
+        [JsonProperty("deanimate_gif")]
+        public string DeanimateGif { get; set; }
+
+        public string Permalink { get; set; }
+
+        [JsonProperty("permalink_public")]
+        public string PermalinkPublic { get; set; }
+    }
+}

--- a/src/SlackConnector/Extensions/FileExtensions.cs
+++ b/src/SlackConnector/Extensions/FileExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using SlackConnector.Connections.Sockets.Messages.Inbound;
+using SlackConnector.Models;
+
+namespace SlackConnector.Extensions
+{
+    internal static class FileExtensions
+    {
+        public static SlackFile ToSlackFile(this File file)
+        {
+            if (file == null)
+                return null;
+
+            return new SlackFile(
+                file.Id,
+                file.Created,
+                file.Timestamp,
+                file.Name,
+                file.Title,
+                file.Mimetype,
+                file.FileType,
+                file.PrettyType,
+                file.User,
+                file.Editable,
+                file.Size,
+                file.Mode,
+                file.IsExternal,
+                file.ExternalType,
+                file.IsPublic,
+                file.PublicUrlShared,
+                file.DisplayAsBot,
+                file.Username,
+                CreateUri(file.UrlPrivate),
+                CreateUri(file.UrlPrivateDownload),
+                file.ImageExifRotation,
+                file.OriginalWidth,
+                file.OriginalHeight,
+                CreateUri(file.DeanimateGif),
+                CreateUri(file.Permalink),
+                CreateUri(file.PermalinkPublic),
+                new SlackThumbnail(
+                    CreateUri(file.Thumb64),
+                    CreateUri(file.Thumb80),
+                    CreateUri(file.Thumb360),
+                    file.Thumb360Width,
+                    file.Thumb360Height,
+                    CreateUri(file.Thumb160),
+                    CreateUri(file.Thumb360Gif)
+                )
+            );
+        }
+
+        private static Uri CreateUri(string url)
+        {
+            return Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri)
+                ? uri
+                : null;
+        }
+    }
+}

--- a/src/SlackConnector/ISlackConnection.cs
+++ b/src/SlackConnector/ISlackConnection.cs
@@ -118,6 +118,11 @@ namespace SlackConnector
         Task Ping();
 
         /// <summary>
+        /// Downloads a file from slack. Best used in conjunction with the file class found in SlackMessage
+        /// </summary>
+        Task<Stream> DownloadFile(Uri downloadUri);
+
+        /// <summary>
         /// Raised when the websocket disconnects from the mothership.
         /// </summary>
         event DisconnectEventHandler OnDisconnect;

--- a/src/SlackConnector/Models/SlackFile.cs
+++ b/src/SlackConnector/Models/SlackFile.cs
@@ -1,0 +1,93 @@
+﻿using System;
+
+namespace SlackConnector.Models
+{
+    public class SlackFile
+    {
+        public string Id { get; }
+        public int Created { get; }
+        public int Timestamp { get; }
+        public string Name { get; }
+        public string Title { get; }
+        public string Mimetype { get; }
+        public string FileType { get; }
+        public string PrettyType { get; }
+        public string User { get; }
+        public bool Editable { get; }
+        public int Size { get; }
+        public string Mode { get; }
+        public bool IsExternal { get; }
+        public string ExternalType { get; }
+        public bool IsPublic { get; }
+        public bool PublicUrlShared { get; }
+        public bool DisplayAsBot { get; }
+        public string Username { get; }
+        public Uri UrlPrivate { get; }
+        public Uri UrlPrivateDownload { get; }
+        public int ImageExifRotation { get; }
+        public int OriginalWidth { get; }
+        public int OriginalHeight { get; }
+        public Uri DeanimateGif { get; }
+        public Uri Permalink { get; }
+        public Uri PermalinkPublic { get; }
+        public SlackThumbnail Thumbnail { get; }
+
+        public SlackFile(
+            string id,
+            int created,
+            int timestamp,
+            string name,
+            string title,
+            string mimetype,
+            string fileType,
+            string prettyType,
+            string user,
+            bool editable,
+            int size,
+            string mode,
+            bool isExternal,
+            string externalType,
+            bool isPublic,
+            bool publicUrlShared,
+            bool displayAsBot,
+            string username,
+            Uri urlPrivate,
+            Uri urlPrivateDownload,
+            int imageExifRotation,
+            int originalWidth,
+            int originalHeight,
+            Uri deanimateGif,
+            Uri permalink,
+            Uri permalinkPublic,
+            SlackThumbnail thumbnail)
+        {
+            Id = id;
+            Created = created;
+            Timestamp = timestamp;
+            Name = name;
+            Title = title;
+            Mimetype = mimetype;
+            FileType = fileType;
+            PrettyType = prettyType;
+            User = user;
+            Editable = editable;
+            Size = size;
+            Mode = mode;
+            IsExternal = isExternal;
+            ExternalType = externalType;
+            IsPublic = isPublic;
+            PublicUrlShared = publicUrlShared;
+            DisplayAsBot = displayAsBot;
+            Username = username;
+            UrlPrivate = urlPrivate;
+            UrlPrivateDownload = urlPrivateDownload;
+            ImageExifRotation = imageExifRotation;
+            OriginalWidth = originalWidth;
+            OriginalHeight = originalHeight;
+            DeanimateGif = deanimateGif;
+            Permalink = permalink;
+            PermalinkPublic = permalinkPublic;
+            Thumbnail = thumbnail;
+        }
+    }
+}

--- a/src/SlackConnector/Models/SlackMessage.cs
+++ b/src/SlackConnector/Models/SlackMessage.cs
@@ -9,5 +9,6 @@
         public SlackUser User { get; set; }
         public double Timestamp { get; set; }
         public SlackMessageSubType MessageSubType { get; set; }
+        public SlackFile File { get; set; }
     }
 }

--- a/src/SlackConnector/Models/SlackThumbnail.cs
+++ b/src/SlackConnector/Models/SlackThumbnail.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace SlackConnector.Models
+{
+    public class SlackThumbnail
+    {
+        public Uri Thumb64 { get; }
+        public Uri Thumb80 { get; }
+        public Uri Thumb360 { get; }
+        public int Thumb360Width { get; }
+        public int Thumb360Height { get; }
+        public Uri Thumb160 { get; }
+        public Uri Thumb360Gif { get; }
+
+        public SlackThumbnail(
+            Uri thumb64,
+            Uri thumb80,
+            Uri thumb360,
+            int thumb360Width,
+            int thumb360Height,
+            Uri thumb160,
+            Uri thumb360Gif)
+        {
+            Thumb64 = thumb64;
+            Thumb80 = thumb80;
+            Thumb360 = thumb360;
+            Thumb360Width = thumb360Width;
+            Thumb360Height = thumb360Height;
+            Thumb160 = thumb160;
+            Thumb360Gif = thumb360Gif;
+        }
+    }
+}

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -123,7 +123,8 @@ namespace SlackConnector
                 ChatHub = GetChatHub(inboundMessage.Channel),
                 RawData = inboundMessage.RawData,
                 MentionsBot = _mentionDetector.WasBotMentioned(Self.Name, Self.Id, inboundMessage.Text),
-                MessageSubType = inboundMessage.MessageSubType.ToSlackMessageSubType()
+                MessageSubType = inboundMessage.MessageSubType.ToSlackMessageSubType(),
+                File = inboundMessage.File.ToSlackFile()
             };
 
             return RaiseMessageReceived(message);

--- a/src/SlackConnector/SlackConnection.cs
+++ b/src/SlackConnector/SlackConnection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Flurl.Http;
 using SlackConnector.BotHelpers;
 using SlackConnector.Connections;
 using SlackConnector.Connections.Clients.Channel;
@@ -452,6 +453,19 @@ namespace SlackConnector
         public async Task Ping()
         {
             await _webSocketClient.SendMessage(new PingMessage());
+        }
+
+        public Task<Stream> DownloadFile(Uri downloadUri)
+        {
+            if (!downloadUri.Host.Equals("files.slack.com"))
+            {
+                throw new ArgumentException("Invalid uri. Should be targetting files.slack.com", nameof(downloadUri));
+            }
+
+            return downloadUri.AbsoluteUri
+                .WithOAuthBearerToken(SlackKey)
+                .AllowHttpStatus()
+                .GetStreamAsync();
         }
 
         public event DisconnectEventHandler OnDisconnect;

--- a/tests/SlackConnector.Tests.Integration/FileDownloadTests.cs
+++ b/tests/SlackConnector.Tests.Integration/FileDownloadTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using Shouldly;
+using SixLabors.ImageSharp;
+using Xunit;
+
+namespace SlackConnector.Tests.Integration
+{
+    public class FileDownloadTests : IntegrationTest
+    {
+        [Fact]
+        public async Task should_download_file()
+        {
+            // given
+            var uri = new Uri("https://files.slack.com/files-pri/T3NFBGBAS-FBUSTA0P4/fuuuu.gif");
+
+            // when
+            var download = await SlackConnection.DownloadFile(uri);
+
+            // then
+            using (download)
+            {
+                download.ShouldNotBeNull();
+                download.Length.ShouldBeGreaterThan(0);
+
+                var image = Image.Load(download);
+                image.Width.ShouldBe(43);
+                image.Height.ShouldBe(29);
+            }
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
+++ b/tests/SlackConnector.Tests.Integration/SlackConnector.Tests.Integration.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/tests/SlackConnector.Tests.Integration/SlackConnectorTests.cs
+++ b/tests/SlackConnector.Tests.Integration/SlackConnectorTests.cs
@@ -22,7 +22,7 @@ namespace SlackConnector.Tests.Integration
 
             // then
             SlackConnection.IsConnected.ShouldBeTrue();
-            //Thread.Sleep(TimeSpan.FromMinutes(1));
+            Thread.Sleep(TimeSpan.FromMinutes(1));
 
             // when
             await SlackConnection.Close();

--- a/tests/SlackConnector.Tests.Integration/SlackConnectorTests.cs
+++ b/tests/SlackConnector.Tests.Integration/SlackConnectorTests.cs
@@ -22,7 +22,7 @@ namespace SlackConnector.Tests.Integration
 
             // then
             SlackConnection.IsConnected.ShouldBeTrue();
-            Thread.Sleep(TimeSpan.FromMinutes(1));
+            //Thread.Sleep(TimeSpan.FromMinutes(5));
 
             // when
             await SlackConnection.Close();

--- a/tests/SlackConnector.Tests.Unit/Connections/Sockets/Messages/MessageInterpreterTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Connections/Sockets/Messages/MessageInterpreterTests.cs
@@ -46,6 +46,100 @@ namespace SlackConnector.Tests.Unit.Connections.Sockets.Messages
         }
 
         [Theory, AutoMoqData]
+        private void should_return_message_with_file(MessageInterpreter interpreter)
+        {
+            // given
+            string json = @"
+                {
+                  'type': 'message',
+                  'file':{
+                      'id':'some-id',
+                      'created':12345,
+                      'timestamp':54321,
+                      'name':'name.gif',
+                      'title':'title.gif',
+                      'mimetype':'image\/gif',
+                      'filetype':'gif',
+                      'pretty_type':'GIF',
+                      'user':'some-user',
+                      'editable':true,
+                      'size':63689,
+                      'mode':'hosted',
+                      'is_external':true,
+                      'external_type':'some-external-type',
+                      'is_public':true,
+                      'public_url_shared':true,
+                      'display_as_bot':true,
+                      'username':'some-username',
+                      'url_private':'https:\/\/url_private',
+                      'url_private_download':'https:\/\/url_private_download',
+                      'thumb_64':'https:\/\/thumb_64',
+                      'thumb_80':'https:\/\/thumb_80',
+                      'thumb_360':'https:\/\/thumb_360',
+                      'thumb_360_w':43,
+                      'thumb_360_h':29,
+                      'thumb_160':'https:\/\/thumb_160',
+                      'thumb_360_gif':'https:\/\/thumb_360_gif',
+                      'image_exif_rotation':6,
+                      'original_w':53,
+                      'original_h':39,
+                      'deanimate_gif':'https:\/\/deanimate_gif',
+                      'permalink':'https:\/\/permalink',
+                      'permalink_public':'https:\/\/permalink_public'
+                   }
+                }
+            ";
+
+            // when
+            var result = interpreter.InterpretMessage(json);
+
+            // then
+            var expected = new ChatMessage
+            {
+                MessageType = MessageType.Message,
+                File = new File
+                {
+                    Id = "some-id",
+                    Created = 12345,
+                    Timestamp = 54321,
+                    Name = "name.gif",
+                    Title = "title.gif",
+                    Mimetype = "image/gif",
+                    FileType = "gif",
+                    PrettyType = "GIF",
+                    User = "some-user",
+                    Editable = true,
+                    Size = 63689,
+                    Mode = "hosted",
+                    IsExternal = true,
+                    ExternalType = "some-external-type",
+                    IsPublic = true,
+                    PublicUrlShared = true,
+                    DisplayAsBot = true,
+                    Username = "some-username",
+                    UrlPrivate = "https://url_private",
+                    UrlPrivateDownload = "https://url_private_download",
+                    Thumb64 = "https://thumb_64",
+                    Thumb80 = "https://thumb_80",
+                    Thumb360 = "https://thumb_360",
+                    Thumb360Width = 43,
+                    Thumb360Height = 29,
+                    Thumb160 = "https://thumb_160",
+                    Thumb360Gif = "https://thumb_360_gif",
+                    ImageExifRotation = 6,
+                    OriginalWidth = 53,
+                    OriginalHeight = 39,
+                    DeanimateGif = "https://deanimate_gif",
+                    Permalink = "https://permalink",
+                    PermalinkPublic = "https://permalink_public"
+                },
+                RawData = json
+            };
+
+            result.ShouldLookLike(expected);
+        }
+
+        [Theory, AutoMoqData]
         private void should_return_group_joined_message(MessageInterpreter interpreter)
         {
             // given

--- a/tests/SlackConnector.Tests.Unit/Extensions/FileExtensionsTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Extensions/FileExtensionsTests.cs
@@ -1,0 +1,84 @@
+﻿using AutoFixture;
+using Shouldly;
+using SlackConnector.Connections.Sockets.Messages.Inbound;
+using SlackConnector.Extensions;
+using Xunit;
+
+namespace SlackConnector.Tests.Unit.Extensions
+{
+    public class FileExtensionsTests
+    {
+        [Theory, AutoMoqData]
+        private void should_return_null()
+        {
+            // given
+            File file = null;
+
+            // when
+            var slackFile = file.ToSlackFile();
+
+            // then
+            slackFile.ShouldBeNull();
+        }
+
+
+        [Theory, AutoMoqData]
+        private void should_return_slack_message(Fixture fixture)
+        {
+            // given
+            var file = fixture.Build<File>()
+                .With(f => f.UrlPrivate, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.UrlPrivateDownload, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Permalink, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.PermalinkPublic, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Thumb160, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Thumb360, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Thumb360Gif, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Thumb64, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.Thumb80, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .With(f => f.DeanimateGif, $"https://{fixture.Create<string>()}.com/{fixture.Create<string>()}")
+                .Create();
+
+            // when
+            var slackFile = file.ToSlackFile();
+
+            // then
+            slackFile.ShouldNotBeNull();
+            slackFile.Id.ShouldBe(file.Id);
+            slackFile.Created.ShouldBe(file.Created);
+            slackFile.Timestamp.ShouldBe(file.Timestamp);
+            slackFile.Name.ShouldBe(file.Name);
+            slackFile.Title.ShouldBe(file.Title);
+            slackFile.Mimetype.ShouldBe(file.Mimetype);
+            slackFile.FileType.ShouldBe(file.FileType);
+            slackFile.PrettyType.ShouldBe(file.PrettyType);
+            slackFile.User.ShouldBe(file.User);
+            slackFile.Editable.ShouldBe(file.Editable);
+            slackFile.Size.ShouldBe(file.Size);
+            slackFile.Mode.ShouldBe(file.Mode);
+            slackFile.IsExternal.ShouldBe(file.IsExternal);
+            slackFile.ExternalType.ShouldBe(file.ExternalType);
+            slackFile.IsPublic.ShouldBe(file.IsPublic);
+            slackFile.PublicUrlShared.ShouldBe(file.PublicUrlShared);
+            slackFile.DisplayAsBot.ShouldBe(file.DisplayAsBot);
+            slackFile.Username.ShouldBe(file.Username);
+            slackFile.UrlPrivate.AbsoluteUri.ShouldBe(file.UrlPrivate);
+            slackFile.UrlPrivateDownload.AbsoluteUri.ShouldBe(file.UrlPrivateDownload);
+            slackFile.ImageExifRotation.ShouldBe(file.ImageExifRotation);
+            slackFile.OriginalWidth.ShouldBe(file.OriginalWidth);
+            slackFile.OriginalHeight.ShouldBe(file.OriginalHeight);
+            slackFile.DeanimateGif.AbsoluteUri.ShouldBe(file.DeanimateGif);
+            slackFile.Permalink.AbsoluteUri.ShouldBe(file.Permalink);
+            slackFile.PermalinkPublic.AbsoluteUri.ShouldBe(file.PermalinkPublic);
+
+            slackFile.Thumbnail.ShouldNotBeNull();
+            slackFile.Thumbnail.Thumb64.AbsoluteUri.ShouldBe(file.Thumb64);
+            slackFile.Thumbnail.Thumb80.AbsoluteUri.ShouldBe(file.Thumb80);
+            slackFile.Thumbnail.Thumb360.AbsoluteUri.ShouldBe(file.Thumb360);
+            slackFile.Thumbnail.Thumb360Width.ShouldBe(file.Thumb360Width);
+            slackFile.Thumbnail.Thumb360Height.ShouldBe(file.Thumb360Height);
+            slackFile.Thumbnail.Thumb160.AbsoluteUri.ShouldBe(file.Thumb160);
+            slackFile.Thumbnail.Thumb360Gif.AbsoluteUri.ShouldBe(file.Thumb360Gif);
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/SlackConnectionTests/DownloadFileTests.cs
+++ b/tests/SlackConnector.Tests.Unit/SlackConnectionTests/DownloadFileTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using AutoFixture;
+using Flurl.Http.Testing;
+using Moq;
+using Shouldly;
+using SlackConnector.Connections.Sockets;
+using SlackConnector.Models;
+using Xunit;
+
+namespace SlackConnector.Tests.Unit.SlackConnectionTests
+{
+    public class DownloadFileTests
+    {
+        [Theory, AutoMoqData]
+        private async Task should_return_stream(
+            Mock<IWebSocketClient> webSocket,
+            SlackConnection slackConnection,
+            string slackKey,
+            Fixture fixture)
+        {
+            using (var httpTest = new HttpTest())
+            {
+                // given
+                var downloadUri = new Uri($"https://files.slack.com/{fixture.Create<string>()}");
+
+                var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+                await slackConnection.Initialise(connectionInfo);
+
+                httpTest
+                    .RespondWithJson(new { fakeObject = true });
+
+                // when
+                var result = await slackConnection.DownloadFile(downloadUri);
+
+                // then
+                result.ShouldNotBeNull();
+                httpTest
+                    .ShouldHaveCalled(downloadUri.AbsoluteUri)
+                    .WithOAuthBearerToken(slackKey);
+            }
+        }
+
+        [Theory, AutoMoqData]
+        private async Task throws_exception_if_uri_isnt_slack(
+            Mock<IWebSocketClient> webSocket,
+            SlackConnection slackConnection,
+            string slackKey,
+            Fixture fixture)
+        {
+            // given
+            var downloadUri = new Uri($"https://something.com/{fixture.Create<string>()}");
+
+            var connectionInfo = new ConnectionInformation { WebSocket = webSocket.Object, SlackKey = slackKey };
+            await slackConnection.Initialise(connectionInfo);
+
+            // when
+            var exception = Should.Throw<ArgumentException>(async () => await slackConnection.DownloadFile(downloadUri));
+
+            // then
+            exception.ShouldNotBeNull();
+            exception.Message.ShouldContain("Invalid uri");
+        }
+    }
+}

--- a/tests/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
+++ b/tests/SlackConnector.Tests.Unit/Stubs/SlackConnectionStub.cs
@@ -86,6 +86,11 @@ namespace SlackConnector.Tests.Unit.Stubs
             throw new NotImplementedException();
         }
 
+        public Task<Stream> DownloadFile(Uri downloadUri)
+        {
+            throw new NotImplementedException();
+        }
+
         public event DisconnectEventHandler OnDisconnect;
         public void RaiseOnDisconnect()
         {


### PR DESCRIPTION
Resolves #9 

SlackMessage now contains a File property, containing all the meta information about any uploaded file.

To download an attachment/file, once you have the Uri simply use the following method:
```csharp
var uri = new Uri("https://files.slack.com/files-pri/some/file.png");
var download = await slackConnection.DownloadFile(uri);
```