### PR TITLE
Adds `footer` and `footer_icon` to message attachment model

### DIFF
--- a/src/SlackConnector/Models/SlackAttachment.cs
+++ b/src/SlackConnector/Models/SlackAttachment.cs
@@ -47,9 +47,15 @@ namespace SlackConnector.Models
         [JsonProperty(PropertyName = "thumb_url")]
         public string ThumbUrl { get; set; }
 
+        [JsonProperty(PropertyName = "footer")]
+        public string Footer { get; set; }
+
+        [JsonProperty(PropertyName = "footer_icon")]
+        public string FooterIcon { get; set; }
+
         [JsonProperty(PropertyName = "mrkdwn_in")]
         public List<string> MarkdownIn { get; set; }
-        
+
         public SlackAttachment()
         {
             Fields = new List<SlackAttachmentField>();

--- a/tests/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
+++ b/tests/SlackConnector.Tests.Unit/Models/SlackAttachmentSerialisationTests.cs
@@ -60,7 +60,9 @@ namespace SlackConnector.Tests.Unit.Models
                         }
                     },
                     ImageUrl = "http://my-website.com/path/to/image.jpg",
-                    ThumbUrl = "http://example.com/path/to/thumb.png"
+                    ThumbUrl = "http://example.com/path/to/thumb.png",
+                    Footer = "Brief text to help contextualize an attachment",
+                    FooterIcon = "http://flickr.com/icons/footer.jpg"
                 };
 
             // when

--- a/tests/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
+++ b/tests/SlackConnector.Tests.Unit/Resources/Inputs/Attachments.json
@@ -40,5 +40,7 @@
     ],
     "image_url": "http://my-website.com/path/to/image.jpg",
     "thumb_url": "http://example.com/path/to/thumb.png",
+    "footer": "Brief text to help contextualize an attachment",
+    "footer_icon": "http://flickr.com/icons/footer.jpg",
     "mrkdwn_in": ["fields","pretext","text"]
 }


### PR DESCRIPTION
This add the properties `footer` and `footer_icon` to the message attachment model.
Description of both can be found in the Slack documentation:
https://api.slack.com/docs/message-attachments

Adapted the serialization unit test accordingly.