### PR TITLE
Update RTM Connection Endpoint

### DIFF
--- a/src/SlackConnector/Connections/Clients/Handshake/FlurlHandshakeClient.cs
+++ b/src/SlackConnector/Connections/Clients/Handshake/FlurlHandshakeClient.cs
@@ -8,7 +8,7 @@ namespace SlackConnector.Connections.Clients.Handshake
     internal class FlurlHandshakeClient : IHandshakeClient
     {
         private readonly IResponseVerifier _responseVerifier;
-        internal const string HANDSHAKE_PATH = "/api/rtm.start";
+        internal const string HANDSHAKE_PATH = "/api/rtm.connect";
 
         public FlurlHandshakeClient(IResponseVerifier responseVerifier)
         {


### PR DESCRIPTION
This addresses the issue of new bot registrations getting an error on start-up connecting to the RTM API stating "method_deprecated", and then getting "invalid_auth" if using the new App style setup. This is because the Slack `rtmstart` endpoint is deprecated now and `rtm.connect` should be used instead. Luckily it appears to be a drop in replacement based on the API documents, so appears to be a small change.

Endpoints
Old: https://api.slack.com/methods/rtm.start
New: https://api.slack.com/methods/rtm.connect

This is linked to the issue I opened originally against Noboot: https://github.com/noobot/noobot/issues/121

This will need a new Nuget package to be released.

Here's a screenshot showing the Noobot.Console project being able to connect using a new style bot token now, using the new endpoint by directly referencing the SlackConnector project with the changes applied in this PR.

![2021-12-01 16_48_04-Window](https://user-images.githubusercontent.com/3891630/144276961-704afb82-d817-477e-b9d3-48dff1097b26.png)

